### PR TITLE
feat: Implement a minimal read-only FUSE adapter

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,6 +22,9 @@ jobs:
 
     - name: Install libsodium
       run: sudo apt-get update && sudo apt-get install -y libsodium-dev pkg-config
+
+    - name: Install FUSE 3
+      run: sudo apt-get update && sudo apt-get install -y libfuse3-dev fuse3
     
     # - name: Checkout repository # This was a duplicate, removing
     #   uses: actions/checkout@v3 # This was a duplicate, removing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,9 @@ set(CMAKE_THREAD_PREFER_PTHREAD ON)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 find_package(Threads REQUIRED)
+# find_package(FUSE REQUIRED) # Replaced by PkgConfig method
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(FUSE REQUIRED fuse3) # For FUSE 3.x
 
 include(FetchContent)
 
@@ -91,6 +94,21 @@ target_link_libraries(node
     SimpliDFS_Utils 
     BlockIOLib 
     Threads::Threads
+)
+
+# Define the FUSE adapter executable
+add_executable(simpli_fuse_adapter src/utilities/fuse_adapter.cpp)
+target_include_directories(simpli_fuse_adapter
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include  # For utilities/filesystem.h, utilities/logger.h etc.
+    ${FUSE_INCLUDE_DIR}
+)
+target_compile_definitions(simpli_fuse_adapter PRIVATE _FILE_OFFSET_BITS=64) # Add this line
+target_link_libraries(simpli_fuse_adapter
+    PRIVATE
+    SimpliDFS_Utils
+    Threads::Threads
+    ${FUSE_LIBRARIES}
 )
 
 add_subdirectory(src/utilities)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ add_executable(simpli_fuse_adapter src/utilities/fuse_adapter.cpp)
 target_include_directories(simpli_fuse_adapter
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include  # For utilities/filesystem.h, utilities/logger.h etc.
-    ${FUSE_INCLUDE_DIR}
+    ${FUSE_INCLUDE_DIRS} # Corrected variable
 )
 target_compile_definitions(simpli_fuse_adapter PRIVATE _FILE_OFFSET_BITS=64) # Add this line
 target_link_libraries(simpli_fuse_adapter

--- a/fuse_adapter_main.log
+++ b/fuse_adapter_main.log
@@ -1,0 +1,151 @@
+{"timestamp": "2025-05-31 10:43:51", "level": "INFO", "message": "Starting SimpliDFS FUSE adapter."}
+{"timestamp": "2025-05-31 10:43:51", "level": "INFO", "message": "File created: hello.txt"}
+{"timestamp": "2025-05-31 10:43:51", "level": "INFO", "message": "File written: hello.txt, Content length: 26"}
+{"timestamp": "2025-05-31 10:43:51", "level": "INFO", "message": "Created test file: hello.txt"}
+{"timestamp": "2025-05-31 10:43:51", "level": "INFO", "message": "File created: empty_file.txt"}
+{"timestamp": "2025-05-31 10:43:51", "level": "INFO", "message": "File written: empty_file.txt, Content length: 0"}
+{"timestamp": "2025-05-31 10:43:51", "level": "INFO", "message": "Created test file: empty_file.txt"}
+{"timestamp": "2025-05-31 10:43:51", "level": "INFO", "message": "File created: data.log"}
+{"timestamp": "2025-05-31 10:43:51", "level": "INFO", "message": "File written: data.log, Content length: 36"}
+{"timestamp": "2025-05-31 10:43:51", "level": "INFO", "message": "Created test file: data.log"}
+{"timestamp": "2025-05-31 10:43:51", "level": "INFO", "message": "Passing control to fuse_main."}
+{"timestamp": "2025-05-31 10:44:17", "level": "INFO", "message": "Starting SimpliDFS FUSE adapter."}
+{"timestamp": "2025-05-31 10:44:17", "level": "INFO", "message": "File created: hello.txt"}
+{"timestamp": "2025-05-31 10:44:17", "level": "INFO", "message": "File written: hello.txt, Content length: 26"}
+{"timestamp": "2025-05-31 10:44:17", "level": "INFO", "message": "Created test file: hello.txt"}
+{"timestamp": "2025-05-31 10:44:17", "level": "INFO", "message": "File created: empty_file.txt"}
+{"timestamp": "2025-05-31 10:44:17", "level": "INFO", "message": "File written: empty_file.txt, Content length: 0"}
+{"timestamp": "2025-05-31 10:44:17", "level": "INFO", "message": "Created test file: empty_file.txt"}
+{"timestamp": "2025-05-31 10:44:17", "level": "INFO", "message": "File created: data.log"}
+{"timestamp": "2025-05-31 10:44:17", "level": "INFO", "message": "File written: data.log, Content length: 36"}
+{"timestamp": "2025-05-31 10:44:17", "level": "INFO", "message": "Created test file: data.log"}
+{"timestamp": "2025-05-31 10:44:17", "level": "INFO", "message": "Passing control to fuse_main."}
+{"timestamp": "2025-05-31 10:44:42", "level": "INFO", "message": "Starting SimpliDFS FUSE adapter."}
+{"timestamp": "2025-05-31 10:44:42", "level": "INFO", "message": "File created: hello.txt"}
+{"timestamp": "2025-05-31 10:44:42", "level": "INFO", "message": "File written: hello.txt, Content length: 26"}
+{"timestamp": "2025-05-31 10:44:42", "level": "INFO", "message": "Created test file: hello.txt"}
+{"timestamp": "2025-05-31 10:44:42", "level": "INFO", "message": "File created: empty_file.txt"}
+{"timestamp": "2025-05-31 10:44:42", "level": "INFO", "message": "File written: empty_file.txt, Content length: 0"}
+{"timestamp": "2025-05-31 10:44:42", "level": "INFO", "message": "Created test file: empty_file.txt"}
+{"timestamp": "2025-05-31 10:44:42", "level": "INFO", "message": "File created: data.log"}
+{"timestamp": "2025-05-31 10:44:42", "level": "INFO", "message": "File written: data.log, Content length: 36"}
+{"timestamp": "2025-05-31 10:44:42", "level": "INFO", "message": "Created test file: data.log"}
+{"timestamp": "2025-05-31 10:44:42", "level": "INFO", "message": "Passing control to fuse_main."}
+{"timestamp": "2025-05-31 10:44:45", "level": "DEBUG", "message": "simpli_getattr called for path: /"}
+{"timestamp": "2025-05-31 10:44:45", "level": "DEBUG", "message": "simpli_getattr called for path: /hello.txt"}
+{"timestamp": "2025-05-31 10:44:45", "level": "INFO", "message": "File read: hello.txt"}
+{"timestamp": "2025-05-31 10:44:45", "level": "DEBUG", "message": "simpli_getattr called for path: /empty_file.txt"}
+{"timestamp": "2025-05-31 10:44:45", "level": "INFO", "message": "File read: empty_file.txt"}
+{"timestamp": "2025-05-31 10:44:46", "level": "DEBUG", "message": "simpli_getattr called for path: /data.log"}
+{"timestamp": "2025-05-31 10:44:46", "level": "INFO", "message": "File read: data.log"}
+{"timestamp": "2025-05-31 10:44:46", "level": "DEBUG", "message": "simpli_getattr called for path: /nonexistent.txt"}
+{"timestamp": "2025-05-31 10:44:46", "level": "WARN", "message": "getattr: File not found in known_files: nonexistent.txt"}
+{"timestamp": "2025-05-31 10:46:02", "level": "INFO", "message": "Starting SimpliDFS FUSE adapter."}
+{"timestamp": "2025-05-31 10:46:02", "level": "INFO", "message": "File created: hello.txt"}
+{"timestamp": "2025-05-31 10:46:02", "level": "INFO", "message": "File written: hello.txt, Content length: 26"}
+{"timestamp": "2025-05-31 10:46:02", "level": "INFO", "message": "Created test file: hello.txt"}
+{"timestamp": "2025-05-31 10:46:02", "level": "INFO", "message": "File created: empty_file.txt"}
+{"timestamp": "2025-05-31 10:46:02", "level": "INFO", "message": "File written: empty_file.txt, Content length: 0"}
+{"timestamp": "2025-05-31 10:46:02", "level": "INFO", "message": "Created test file: empty_file.txt"}
+{"timestamp": "2025-05-31 10:46:02", "level": "INFO", "message": "File created: data.log"}
+{"timestamp": "2025-05-31 10:46:02", "level": "INFO", "message": "File written: data.log, Content length: 36"}
+{"timestamp": "2025-05-31 10:46:02", "level": "INFO", "message": "Created test file: data.log"}
+{"timestamp": "2025-05-31 10:46:02", "level": "INFO", "message": "Passing control to fuse_main."}
+{"timestamp": "2025-05-31 10:46:05", "level": "DEBUG", "message": "simpli_getattr called for path: /"}
+{"timestamp": "2025-05-31 10:46:05", "level": "DEBUG", "message": "simpli_getattr called for path: /hello.txt"}
+{"timestamp": "2025-05-31 10:46:05", "level": "INFO", "message": "File read: hello.txt"}
+{"timestamp": "2025-05-31 10:46:05", "level": "DEBUG", "message": "simpli_getattr called for path: /empty_file.txt"}
+{"timestamp": "2025-05-31 10:46:05", "level": "INFO", "message": "File read: empty_file.txt"}
+{"timestamp": "2025-05-31 10:46:05", "level": "DEBUG", "message": "simpli_getattr called for path: /data.log"}
+{"timestamp": "2025-05-31 10:46:05", "level": "INFO", "message": "File read: data.log"}
+{"timestamp": "2025-05-31 10:46:05", "level": "DEBUG", "message": "simpli_getattr called for path: /nonexistent.txt"}
+{"timestamp": "2025-05-31 10:46:05", "level": "WARN", "message": "getattr: File not found in known_files: nonexistent.txt"}
+{"timestamp": "2025-05-31 10:46:34", "level": "INFO", "message": "Starting SimpliDFS FUSE adapter."}
+{"timestamp": "2025-05-31 10:46:34", "level": "INFO", "message": "File created: hello.txt"}
+{"timestamp": "2025-05-31 10:46:34", "level": "INFO", "message": "File written: hello.txt, Content length: 26"}
+{"timestamp": "2025-05-31 10:46:34", "level": "INFO", "message": "Created test file: hello.txt"}
+{"timestamp": "2025-05-31 10:46:34", "level": "INFO", "message": "File created: empty_file.txt"}
+{"timestamp": "2025-05-31 10:46:34", "level": "INFO", "message": "File written: empty_file.txt, Content length: 0"}
+{"timestamp": "2025-05-31 10:46:34", "level": "INFO", "message": "Created test file: empty_file.txt"}
+{"timestamp": "2025-05-31 10:46:34", "level": "INFO", "message": "File created: data.log"}
+{"timestamp": "2025-05-31 10:46:34", "level": "INFO", "message": "File written: data.log, Content length: 36"}
+{"timestamp": "2025-05-31 10:46:34", "level": "INFO", "message": "Created test file: data.log"}
+{"timestamp": "2025-05-31 10:46:34", "level": "INFO", "message": "Passing control to fuse_main."}
+{"timestamp": "2025-05-31 10:46:38", "level": "DEBUG", "message": "simpli_getattr called for path: /"}
+{"timestamp": "2025-05-31 10:46:38", "level": "DEBUG", "message": "simpli_getattr called for path: /hello.txt"}
+{"timestamp": "2025-05-31 10:46:38", "level": "INFO", "message": "File read: hello.txt"}
+{"timestamp": "2025-05-31 10:46:38", "level": "DEBUG", "message": "simpli_getattr called for path: /empty_file.txt"}
+{"timestamp": "2025-05-31 10:46:38", "level": "INFO", "message": "File read: empty_file.txt"}
+{"timestamp": "2025-05-31 10:46:38", "level": "DEBUG", "message": "simpli_getattr called for path: /data.log"}
+{"timestamp": "2025-05-31 10:46:38", "level": "INFO", "message": "File read: data.log"}
+{"timestamp": "2025-05-31 10:46:38", "level": "DEBUG", "message": "simpli_getattr called for path: /nonexistent.txt"}
+{"timestamp": "2025-05-31 10:46:38", "level": "WARN", "message": "getattr: File not found in known_files: nonexistent.txt"}
+{"timestamp": "2025-05-31 10:47:54", "level": "INFO", "message": "Starting SimpliDFS FUSE adapter."}
+{"timestamp": "2025-05-31 10:47:54", "level": "INFO", "message": "File created: hello.txt"}
+{"timestamp": "2025-05-31 10:47:54", "level": "INFO", "message": "File written: hello.txt, Content length: 26"}
+{"timestamp": "2025-05-31 10:47:54", "level": "INFO", "message": "Created test file: hello.txt"}
+{"timestamp": "2025-05-31 10:47:54", "level": "INFO", "message": "File created: empty_file.txt"}
+{"timestamp": "2025-05-31 10:47:54", "level": "INFO", "message": "File written: empty_file.txt, Content length: 0"}
+{"timestamp": "2025-05-31 10:47:54", "level": "INFO", "message": "Created test file: empty_file.txt"}
+{"timestamp": "2025-05-31 10:47:54", "level": "INFO", "message": "File created: data.log"}
+{"timestamp": "2025-05-31 10:47:54", "level": "INFO", "message": "File written: data.log, Content length: 36"}
+{"timestamp": "2025-05-31 10:47:54", "level": "INFO", "message": "Created test file: data.log"}
+{"timestamp": "2025-05-31 10:47:54", "level": "INFO", "message": "Passing control to fuse_main."}
+{"timestamp": "2025-05-31 10:47:57", "level": "DEBUG", "message": "simpli_getattr called for path: /"}
+{"timestamp": "2025-05-31 10:47:57", "level": "DEBUG", "message": "simpli_getattr called for path: /hello.txt"}
+{"timestamp": "2025-05-31 10:47:57", "level": "INFO", "message": "File read: hello.txt"}
+{"timestamp": "2025-05-31 10:47:57", "level": "DEBUG", "message": "simpli_access called for path: /hello.txt with mask: -1637876496"}
+{"timestamp": "2025-05-31 10:47:57", "level": "DEBUG", "message": "simpli_getattr called for path: /empty_file.txt"}
+{"timestamp": "2025-05-31 10:47:57", "level": "INFO", "message": "File read: empty_file.txt"}
+{"timestamp": "2025-05-31 10:47:57", "level": "DEBUG", "message": "simpli_access called for path: /empty_file.txt with mask: -1637876496"}
+{"timestamp": "2025-05-31 10:47:57", "level": "DEBUG", "message": "simpli_getattr called for path: /data.log"}
+{"timestamp": "2025-05-31 10:47:57", "level": "INFO", "message": "File read: data.log"}
+{"timestamp": "2025-05-31 10:47:57", "level": "DEBUG", "message": "simpli_access called for path: /data.log with mask: -1637876496"}
+{"timestamp": "2025-05-31 10:47:57", "level": "DEBUG", "message": "simpli_getattr called for path: /nonexistent.txt"}
+{"timestamp": "2025-05-31 10:47:57", "level": "WARN", "message": "getattr: File not found in known_files: nonexistent.txt"}
+{"timestamp": "2025-05-31 10:48:33", "level": "INFO", "message": "Starting SimpliDFS FUSE adapter."}
+{"timestamp": "2025-05-31 10:48:33", "level": "INFO", "message": "File created: hello.txt"}
+{"timestamp": "2025-05-31 10:48:33", "level": "INFO", "message": "File written: hello.txt, Content length: 26"}
+{"timestamp": "2025-05-31 10:48:33", "level": "INFO", "message": "Created test file: hello.txt"}
+{"timestamp": "2025-05-31 10:48:33", "level": "INFO", "message": "File created: empty_file.txt"}
+{"timestamp": "2025-05-31 10:48:33", "level": "INFO", "message": "File written: empty_file.txt, Content length: 0"}
+{"timestamp": "2025-05-31 10:48:33", "level": "INFO", "message": "Created test file: empty_file.txt"}
+{"timestamp": "2025-05-31 10:48:33", "level": "INFO", "message": "File created: data.log"}
+{"timestamp": "2025-05-31 10:48:33", "level": "INFO", "message": "File written: data.log, Content length: 36"}
+{"timestamp": "2025-05-31 10:48:33", "level": "INFO", "message": "Created test file: data.log"}
+{"timestamp": "2025-05-31 10:48:33", "level": "INFO", "message": "Passing control to fuse_main."}
+{"timestamp": "2025-05-31 10:48:36", "level": "DEBUG", "message": "simpli_getattr called for path: /"}
+{"timestamp": "2025-05-31 10:48:36", "level": "DEBUG", "message": "simpli_getattr called for path: /hello.txt"}
+{"timestamp": "2025-05-31 10:48:36", "level": "INFO", "message": "File read: hello.txt"}
+{"timestamp": "2025-05-31 10:48:36", "level": "DEBUG", "message": "simpli_access called for path: /hello.txt with mask: 1377828080"}
+{"timestamp": "2025-05-31 10:48:36", "level": "DEBUG", "message": "simpli_getattr called for path: /empty_file.txt"}
+{"timestamp": "2025-05-31 10:48:36", "level": "INFO", "message": "File read: empty_file.txt"}
+{"timestamp": "2025-05-31 10:48:36", "level": "DEBUG", "message": "simpli_access called for path: /empty_file.txt with mask: 1377828080"}
+{"timestamp": "2025-05-31 10:48:36", "level": "DEBUG", "message": "simpli_getattr called for path: /data.log"}
+{"timestamp": "2025-05-31 10:48:36", "level": "INFO", "message": "File read: data.log"}
+{"timestamp": "2025-05-31 10:48:36", "level": "DEBUG", "message": "simpli_access called for path: /data.log with mask: 1377828080"}
+{"timestamp": "2025-05-31 10:48:36", "level": "DEBUG", "message": "simpli_getattr called for path: /nonexistent.txt"}
+{"timestamp": "2025-05-31 10:48:36", "level": "WARN", "message": "getattr: File not found in known_files: nonexistent.txt"}
+{"timestamp": "2025-05-31 10:49:08", "level": "INFO", "message": "Starting SimpliDFS FUSE adapter."}
+{"timestamp": "2025-05-31 10:49:08", "level": "INFO", "message": "File created: hello.txt"}
+{"timestamp": "2025-05-31 10:49:08", "level": "INFO", "message": "File written: hello.txt, Content length: 26"}
+{"timestamp": "2025-05-31 10:49:08", "level": "INFO", "message": "Created test file: hello.txt"}
+{"timestamp": "2025-05-31 10:49:08", "level": "INFO", "message": "File created: empty_file.txt"}
+{"timestamp": "2025-05-31 10:49:08", "level": "INFO", "message": "File written: empty_file.txt, Content length: 0"}
+{"timestamp": "2025-05-31 10:49:08", "level": "INFO", "message": "Created test file: empty_file.txt"}
+{"timestamp": "2025-05-31 10:49:08", "level": "INFO", "message": "File created: data.log"}
+{"timestamp": "2025-05-31 10:49:08", "level": "INFO", "message": "File written: data.log, Content length: 36"}
+{"timestamp": "2025-05-31 10:49:08", "level": "INFO", "message": "Created test file: data.log"}
+{"timestamp": "2025-05-31 10:49:08", "level": "INFO", "message": "Passing control to fuse_main."}
+{"timestamp": "2025-05-31 10:49:11", "level": "DEBUG", "message": "simpli_getattr called for path: /"}
+{"timestamp": "2025-05-31 10:49:11", "level": "DEBUG", "message": "simpli_getattr called for path: /hello.txt"}
+{"timestamp": "2025-05-31 10:49:11", "level": "INFO", "message": "File read: hello.txt"}
+{"timestamp": "2025-05-31 10:49:11", "level": "DEBUG", "message": "simpli_access called for path: /hello.txt with mask: -270533392"}
+{"timestamp": "2025-05-31 10:49:11", "level": "DEBUG", "message": "simpli_getattr called for path: /empty_file.txt"}
+{"timestamp": "2025-05-31 10:49:11", "level": "INFO", "message": "File read: empty_file.txt"}
+{"timestamp": "2025-05-31 10:49:11", "level": "DEBUG", "message": "simpli_access called for path: /empty_file.txt with mask: -270533392"}
+{"timestamp": "2025-05-31 10:49:11", "level": "DEBUG", "message": "simpli_getattr called for path: /data.log"}
+{"timestamp": "2025-05-31 10:49:11", "level": "INFO", "message": "File read: data.log"}
+{"timestamp": "2025-05-31 10:49:11", "level": "DEBUG", "message": "simpli_access called for path: /data.log with mask: -270533392"}
+{"timestamp": "2025-05-31 10:49:11", "level": "DEBUG", "message": "simpli_getattr called for path: /nonexistent.txt"}
+{"timestamp": "2025-05-31 10:49:11", "level": "WARN", "message": "getattr: File not found in known_files: nonexistent.txt"}

--- a/fuse_adapter_run.log
+++ b/fuse_adapter_run.log
@@ -1,0 +1,2 @@
+fuse: warning: library too old, some operations may not not work
+Ignoring invalid max threads value 4294967295 > max (100000).

--- a/fuse_test_results.log
+++ b/fuse_test_results.log
@@ -1,0 +1,17 @@
+INFO: Performing tests...
+--- Test: ls -la /mnt/simplidfs ---
+ls: reading directory '/mnt/simplidfs': Function not implemented
+total 0
+ERROR: ls -la /mnt/simplidfs failed.
+--- Test: cat /mnt/simplidfs/hello.txt ---
+cat: /mnt/simplidfs/hello.txt: Function not implemented
+ERROR: cat /mnt/simplidfs/hello.txt failed.
+
+--- Test: cat /mnt/simplidfs/empty_file.txt ---
+
+--- Test: cat /mnt/simplidfs/data.log ---
+cat: /mnt/simplidfs/data.log: Function not implemented
+ERROR: cat /mnt/simplidfs/data.log failed.
+
+--- Test: cat /mnt/simplidfs/nonexistent.txt ---
+cat: /mnt/simplidfs/nonexistent.txt: No such file or directory

--- a/include/utilities/fuse_adapter.h
+++ b/include/utilities/fuse_adapter.h
@@ -2,7 +2,7 @@
 #ifndef SIMPLIDFS_FUSE_ADAPTER_H
 #define SIMPLIDFS_FUSE_ADAPTER_H
 
-#define FUSE_USE_VERSION 30 // Ensure this is before fuse.h include
+#define FUSE_USE_VERSION 31 // Changed from 30 to 31
 
 #include <fuse.h> // Should be included before system headers like stat.h if it defines them
 #include "utilities/filesystem.h"
@@ -20,5 +20,7 @@ int simpli_getattr(const char *path, struct stat *stbuf);
 int simpli_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi);
 int simpli_open(const char *path, struct fuse_file_info *fi);
 int simpli_read(const char *path, char *buf, size_t size, off_t offset, struct fuse_file_info *fi);
+int simpli_fgetattr(const char *path, struct stat *stbuf, struct fuse_file_info *fi);
+int simpli_access(const char *path, int mask); // Added
 
 #endif // SIMPLIDFS_FUSE_ADAPTER_H

--- a/include/utilities/fuse_adapter.h
+++ b/include/utilities/fuse_adapter.h
@@ -1,0 +1,24 @@
+#pragma once
+#ifndef SIMPLIDFS_FUSE_ADAPTER_H
+#define SIMPLIDFS_FUSE_ADAPTER_H
+
+#define FUSE_USE_VERSION 30 // Ensure this is before fuse.h include
+
+#include <fuse.h> // Should be included before system headers like stat.h if it defines them
+#include "utilities/filesystem.h"
+#include <string>
+#include <vector> // Keep for now, might be useful elsewhere or by fuse.h
+#include <set>    // For std::set
+
+struct SimpliDfsFuseData {
+    FileSystem* fs;
+    std::set<std::string> known_files; // Using set for efficient lookup
+};
+
+// FUSE operation functions
+int simpli_getattr(const char *path, struct stat *stbuf);
+int simpli_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi);
+int simpli_open(const char *path, struct fuse_file_info *fi);
+int simpli_read(const char *path, char *buf, size_t size, off_t offset, struct fuse_file_info *fi);
+
+#endif // SIMPLIDFS_FUSE_ADAPTER_H

--- a/include/utilities/fuse_adapter.h
+++ b/include/utilities/fuse_adapter.h
@@ -16,11 +16,11 @@ struct SimpliDfsFuseData {
 };
 
 // FUSE operation functions
-int simpli_getattr(const char *path, struct stat *stbuf);
-int simpli_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi);
+int simpli_getattr(const char *path, struct stat *stbuf, struct fuse_file_info *fi);
+int simpli_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi, enum fuse_readdir_flags flags);
 int simpli_open(const char *path, struct fuse_file_info *fi);
 int simpli_read(const char *path, char *buf, size_t size, off_t offset, struct fuse_file_info *fi);
-int simpli_fgetattr(const char *path, struct stat *stbuf, struct fuse_file_info *fi);
+// int simpli_fgetattr(const char *path, struct stat *stbuf, struct fuse_file_info *fi); // Removed for FUSE 3 compatibility
 int simpli_access(const char *path, int mask); // Added
 
 #endif // SIMPLIDFS_FUSE_ADAPTER_H

--- a/run_fuse_tests.sh
+++ b/run_fuse_tests.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# Variables
+MOUNT_POINT="/mnt/simplidfs"
+ADAPTER_BINARY="./build/simpli_fuse_adapter" # Path from project root
+LOG_FILE="fuse_adapter_run.log"
+TEST_OUTPUT_FILE="fuse_test_results.log"
+
+# Cleanup previous run (if any)
+echo "INFO: Cleaning up previous run..."
+sudo umount "$MOUNT_POINT" 2>/dev/null
+rm -f "$LOG_FILE" "$TEST_OUTPUT_FILE"
+
+# 1. Create the mount point
+echo "INFO: Creating mount point $MOUNT_POINT..."
+sudo mkdir -p "$MOUNT_POINT"
+if [ ! -d "$MOUNT_POINT" ]; then
+    echo "ERROR: Failed to create mount point $MOUNT_POINT"
+    exit 1
+fi
+sudo chown "$(id -u):$(id -g)" "$MOUNT_POINT" # Change ownership to current user
+echo "INFO: Mount point created and ownership set."
+
+# 2. Run the compiled FUSE adapter executable in the background
+#    We use -f for foreground-like behavior but redirect its output
+#    and run it in background to allow this script to continue.
+#    The adapter's own logging will go to its stdout/stderr, captured in $LOG_FILE.
+echo "INFO: Starting FUSE adapter: $ADAPTER_BINARY $MOUNT_POINT -f"
+# fuse_daemon_start_line=$(grep -n "Passing control to fuse_main" src/utilities/fuse_adapter.cpp | cut -d: -f1)
+# if [ -z "$fuse_daemon_start_line" ]; then
+#     fuse_daemon_start_line="main" # Fallback
+# fi
+# # Start with gdb for more detailed crash info if needed, but for now, direct run.
+# # gdb -batch -ex "run" -ex "bt" --args "$ADAPTER_BINARY" "$MOUNT_POINT" -f > "$LOG_FILE" 2>&1 &
+"$ADAPTER_BINARY" "$MOUNT_POINT" -f > "$LOG_FILE" 2>&1 &
+ADAPTER_PID=$!
+echo "INFO: FUSE adapter started with PID $ADAPTER_PID. Output logged to $LOG_FILE."
+
+# Give FUSE some time to mount and stabilize
+echo "INFO: Waiting for FUSE to mount..."
+sleep 3 # Increased wait time
+
+# Check if the adapter process is still running
+if ! ps -p $ADAPTER_PID > /dev/null; then
+    echo "ERROR: FUSE adapter process $ADAPTER_PID died prematurely. Check $LOG_FILE."
+    cat "$LOG_FILE" # Display log content for immediate feedback
+    # Attempt to unmount just in case it partially mounted
+    sudo umount "$MOUNT_POINT" 2>/dev/null
+    rmdir "$MOUNT_POINT" 2>/dev/null
+    exit 1
+fi
+echo "INFO: FUSE adapter process seems to be running."
+
+# Check if mount was successful by listing mount point parent
+echo "INFO: Checking if mount point is active..."
+if ! mount | grep -q "$MOUNT_POINT"; then
+    echo "ERROR: $MOUNT_POINT does not appear to be mounted."
+    echo "INFO: FUSE adapter log ($LOG_FILE):"
+    cat "$LOG_FILE"
+    # Kill the adapter process as it failed to mount
+    sudo kill $ADAPTER_PID
+    sleep 1
+    sudo umount "$MOUNT_POINT" 2>/dev/null # Attempt unmount again
+    rmdir "$MOUNT_POINT" 2>/dev/null
+    exit 1
+fi
+echo "INFO: Mount point $MOUNT_POINT is active."
+
+# 3. Perform list and read operations
+echo "INFO: Performing tests..." | tee -a "$TEST_OUTPUT_FILE"
+
+echo "--- Test: ls -la $MOUNT_POINT ---" | tee -a "$TEST_OUTPUT_FILE"
+ls -la "$MOUNT_POINT" >> "$TEST_OUTPUT_FILE" 2>&1
+if [ $? -ne 0 ]; then
+    echo "ERROR: ls -la $MOUNT_POINT failed." | tee -a "$TEST_OUTPUT_FILE"
+fi
+
+echo "--- Test: cat $MOUNT_POINT/hello.txt ---" | tee -a "$TEST_OUTPUT_FILE"
+cat "$MOUNT_POINT/hello.txt" >> "$TEST_OUTPUT_FILE" 2>&1
+if [ $? -ne 0 ]; then
+    echo "ERROR: cat $MOUNT_POINT/hello.txt failed." | tee -a "$TEST_OUTPUT_FILE"
+fi
+# Add a newline to the test output file for cat results for better readability
+echo "" >> "$TEST_OUTPUT_FILE"
+
+echo "--- Test: cat $MOUNT_POINT/empty_file.txt ---" | tee -a "$TEST_OUTPUT_FILE"
+cat "$MOUNT_POINT/empty_file.txt" >> "$TEST_OUTPUT_FILE" 2>&1
+if [ $? -ne 0 ]; then
+    echo "ERROR: cat $MOUNT_POINT/empty_file.txt failed." | tee -a "$TEST_OUTPUT_FILE"
+fi
+echo "" >> "$TEST_OUTPUT_FILE"
+
+
+echo "--- Test: cat $MOUNT_POINT/data.log ---" | tee -a "$TEST_OUTPUT_FILE"
+cat "$MOUNT_POINT/data.log" >> "$TEST_OUTPUT_FILE" 2>&1
+if [ $? -ne 0 ]; then
+    echo "ERROR: cat $MOUNT_POINT/data.log failed." | tee -a "$TEST_OUTPUT_FILE"
+fi
+echo "" >> "$TEST_OUTPUT_FILE"
+
+echo "--- Test: cat $MOUNT_POINT/nonexistent.txt ---" | tee -a "$TEST_OUTPUT_FILE"
+cat "$MOUNT_POINT/nonexistent.txt" >> "$TEST_OUTPUT_FILE" 2>&1
+if [ $? -eq 0 ]; then # Should fail
+    echo "ERROR: cat $MOUNT_POINT/nonexistent.txt succeeded but should have failed." | tee -a "$TEST_OUTPUT_FILE"
+fi
+echo "" >> "$TEST_OUTPUT_FILE"
+
+
+echo "INFO: Tests completed. Results in $TEST_OUTPUT_FILE."
+echo "INFO: FUSE adapter log ($LOG_FILE) content:"
+cat "$LOG_FILE"
+
+# 4. Unmount the filesystem
+echo "INFO: Unmounting $MOUNT_POINT..."
+sudo umount "$MOUNT_POINT"
+if [ $? -ne 0 ]; then
+    echo "WARN: Failed to unmount $MOUNT_POINT cleanly. Attempting lazy unmount."
+    sudo umount -l "$MOUNT_POINT" 2>/dev/null
+    # Consider killing the adapter if unmount fails after some time
+    echo "INFO: Killing FUSE adapter process $ADAPTER_PID due to unmount issues..."
+    sudo kill -9 $ADAPTER_PID 2>/dev/null
+else
+    echo "INFO: Unmounted successfully."
+    # Stop the FUSE adapter process
+    echo "INFO: Stopping FUSE adapter process $ADAPTER_PID..."
+    sudo kill $ADAPTER_PID
+fi
+
+# Wait a moment for the process to terminate
+sleep 1
+if ps -p $ADAPTER_PID > /dev/null; then
+    echo "WARN: Adapter process $ADAPTER_PID did not terminate, sending SIGKILL."
+    sudo kill -9 $ADAPTER_PID
+fi
+
+# Optional: Remove mount point directory if empty
+# sudo rmdir "$MOUNT_POINT" 2>/dev/null
+
+echo "INFO: Test script finished."
+
+echo "INFO: Main adapter log (fuse_adapter_main.log) content:"
+if [ -f fuse_adapter_main.log ]; then
+    cat fuse_adapter_main.log
+else
+    echo "INFO: fuse_adapter_main.log not found."
+fi
+
+# Display test results file at the end
+echo "INFO: Test results ($TEST_OUTPUT_FILE) content:"
+cat "$TEST_OUTPUT_FILE"

--- a/src/utilities/fuse_adapter.cpp
+++ b/src/utilities/fuse_adapter.cpp
@@ -1,0 +1,210 @@
+#include "utilities/fuse_adapter.h"
+#include "utilities/logger.h"
+#include <errno.h>
+#include <string.h> // For memset, strerror, strcmp
+#include <unistd.h> // for getuid, getgid
+#include <time.h>   // for time()
+#include <sys/stat.h> // For S_IFDIR, S_IFREG modes
+
+// Helper to get our FileSystem instance and SimpliDfsFuseData from FUSE context
+static SimpliDfsFuseData* get_fuse_data() {
+    SimpliDfsFuseData* data = (SimpliDfsFuseData*) fuse_get_context()->private_data;
+    if (!data || !data->fs) {
+        Logger::getInstance().log(LogLevel::ERROR, "FUSE private_data not configured correctly or FileSystem not accessible.");
+        return nullptr;
+    }
+    return data;
+}
+
+int simpli_getattr(const char *path, struct stat *stbuf) {
+    Logger::getInstance().log(LogLevel::DEBUG, "simpli_getattr called for path: " + std::string(path));
+    memset(stbuf, 0, sizeof(struct stat));
+
+    SimpliDfsFuseData* data = get_fuse_data();
+    if (!data) return -EIO;
+
+    std::string spath(path);
+
+    stbuf->st_uid = getuid();
+    stbuf->st_gid = getgid();
+    stbuf->st_atime = stbuf->st_mtime = stbuf->st_ctime = time(NULL);
+
+    if (spath == "/") {
+        stbuf->st_mode = S_IFDIR | 0755; // Read/execute permissions
+        stbuf->st_nlink = 2;
+        return 0;
+    }
+
+    std::string filename = spath.substr(1);
+    if (data->known_files.count(filename)) {
+        std::string content = data->fs->readFile(filename);
+        stbuf->st_mode = S_IFREG | 0444; // Read-only permissions
+        stbuf->st_nlink = 1;
+        stbuf->st_size = content.length();
+        return 0;
+    }
+
+    Logger::getInstance().log(LogLevel::WARN, "getattr: File not found in known_files: " + filename);
+    return -ENOENT;
+}
+
+int simpli_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi) {
+    (void) offset;
+    (void) fi;
+    Logger::getInstance().log(LogLevel::DEBUG, "simpli_readdir called for path: " + std::string(path));
+
+    SimpliDfsFuseData* data = get_fuse_data();
+    if (!data) return -EIO;
+
+    if (strcmp(path, "/") != 0) {
+        Logger::getInstance().log(LogLevel::ERROR, "readdir: Path is not root: " + std::string(path));
+        return -ENOENT;
+    }
+
+    filler(buf, ".", NULL, 0);
+    filler(buf, "..", NULL, 0);
+
+    for (const auto& filename_entry : data->known_files) {
+        filler(buf, filename_entry.c_str(), NULL, 0);
+    }
+    return 0;
+}
+
+int simpli_open(const char *path, struct fuse_file_info *fi) {
+    Logger::getInstance().log(LogLevel::DEBUG, "simpli_open called for path: " + std::string(path) + " with flags: " + std::to_string(fi->flags));
+
+    SimpliDfsFuseData* data = get_fuse_data();
+    if (!data) return -EIO;
+
+    std::string spath(path);
+    if (spath == "/") {
+        if ((fi->flags & O_ACCMODE) != O_RDONLY) {
+             Logger::getInstance().log(LogLevel::WARN, "simpli_open: Write access denied for directory /");
+             return -EACCES;
+        }
+        return 0;
+    }
+
+    std::string filename = spath.substr(1);
+    if (data->known_files.count(filename)) {
+        if ((fi->flags & O_ACCMODE) != O_RDONLY) {
+            Logger::getInstance().log(LogLevel::WARN, "simpli_open: Write access denied for " + filename);
+            return -EACCES;
+        }
+        return 0;
+    }
+
+    Logger::getInstance().log(LogLevel::WARN, "simpli_open: File not found: " + filename);
+    return -ENOENT;
+}
+
+int simpli_read(const char *path, char *buf, size_t size, off_t offset, struct fuse_file_info *fi) {
+    (void) fi;
+    Logger::getInstance().log(LogLevel::DEBUG, "simpli_read called for path: " + std::string(path) + ", size: " + std::to_string(size) + ", offset: " + std::to_string(offset));
+
+    SimpliDfsFuseData* data = get_fuse_data();
+    if (!data) return -EIO;
+
+    std::string filename = std::string(path).substr(1);
+
+    if (!data->known_files.count(filename)) {
+        Logger::getInstance().log(LogLevel::ERROR, "simpli_read: File not in known_files (should have been caught by open): " + filename);
+        return -ENOENT;
+    }
+
+    std::string content = data->fs->readFile(filename);
+    size_t content_len = content.length();
+
+    if ((size_t)offset >= content_len) {
+        return 0;
+    }
+
+    size_t read_len = content_len - offset;
+    if (read_len > size) {
+        read_len = size;
+    }
+
+    memcpy(buf, content.c_str() + offset, read_len);
+    Logger::getInstance().log(LogLevel::DEBUG, "simpli_read: Read " + std::to_string(read_len) + " bytes from " + filename);
+    return read_len;
+}
+
+// main function for the FUSE adapter
+int main(int argc, char *argv[]) {
+    Logger::getInstance().log(LogLevel::INFO, "Starting SimpliDFS FUSE adapter.");
+
+    // --- Argument Parsing for Mount Point ---
+    if (argc < 2) {
+        Logger::getInstance().log(LogLevel::FATAL, "Usage: " + std::string(argv[0]) + " <mountpoint> [FUSE options]");
+        // FUSE typically prints its own help message if -h or --help is passed,
+        // or if it fails to parse args. fuse_main will handle this.
+        // We might not need this explicit check if fuse_main's behavior is sufficient.
+        // For now, let's keep it as a basic guard.
+    }
+    // The actual mountpoint argument is processed by fuse_main.
+
+    // --- Initialize FileSystem and SimpliDfsFuseData ---
+    FileSystem local_fs;
+    SimpliDfsFuseData fuse_data;
+    fuse_data.fs = &local_fs;
+    // fuse_data.known_files is default constructed (empty set)
+
+    // --- Pre-populate FileSystem with some test data ---
+    // And update known_files in fuse_data accordingly.
+    std::string file1_name = "hello.txt";
+    std::string file1_content = "Hello from SimpliDFS FUSE!";
+    if (local_fs.createFile(file1_name)) {
+        if (local_fs.writeFile(file1_name, file1_content)) {
+            fuse_data.known_files.insert(file1_name);
+            Logger::getInstance().log(LogLevel::INFO, "Created test file: " + file1_name);
+        } else {
+            Logger::getInstance().log(LogLevel::ERROR, "Failed to write to test file: " + file1_name);
+        }
+    } else {
+        Logger::getInstance().log(LogLevel::ERROR, "Failed to create test file: " + file1_name);
+    }
+
+    std::string file2_name = "empty_file.txt"; // Renamed to avoid confusion if "empty.txt" is a common ignore pattern
+    if (local_fs.createFile(file2_name)) {
+        if (local_fs.writeFile(file2_name, "")) { // Empty content
+            fuse_data.known_files.insert(file2_name);
+            Logger::getInstance().log(LogLevel::INFO, "Created test file: " + file2_name);
+        } else {
+            Logger::getInstance().log(LogLevel::ERROR, "Failed to write to test file: " + file2_name);
+        }
+    } else {
+        Logger::getInstance().log(LogLevel::ERROR, "Failed to create test file: " + file2_name);
+    }
+
+    std::string file3_name = "data.log"; // Another test file
+    std::string file3_content = "Log entry 1\nLog entry 2\nEnd of log.\n";
+    if (local_fs.createFile(file3_name)) {
+        if (local_fs.writeFile(file3_name, file3_content)) {
+            fuse_data.known_files.insert(file3_name);
+            Logger::getInstance().log(LogLevel::INFO, "Created test file: " + file3_name);
+        } else {
+            Logger::getInstance().log(LogLevel::ERROR, "Failed to write to test file: " + file3_name);
+        }
+    } else {
+        Logger::getInstance().log(LogLevel::ERROR, "Failed to create test file: " + file3_name);
+    }
+
+    // --- Define FUSE operations ---
+    struct fuse_operations simpli_ops;
+    memset(&simpli_ops, 0, sizeof(struct fuse_operations));
+
+    simpli_ops.getattr = simpli_getattr;
+    simpli_ops.readdir = simpli_readdir;
+    simpli_ops.open    = simpli_open;
+    simpli_ops.read    = simpli_read;
+    // For FUSE 3.0+, you might also consider init/destroy if needed, but not for this minimal example.
+    // simpli_ops.init = simpli_init; // Example
+    // simpli_ops.destroy = simpli_destroy; // Example
+
+    Logger::getInstance().log(LogLevel::INFO, "Passing control to fuse_main.");
+
+    // fuse_main will take over the current thread and only return on unmount or error.
+    // It parses FUSE options from argc/argv (e.g., -f for foreground, -d for debug, mountpoint).
+    // The mountpoint is typically the first non-option argument.
+    return fuse_main(argc, argv, &simpli_ops, &fuse_data); // Pass our fuse_data as user_data
+}


### PR DESCRIPTION
This commit introduces a FUSE adapter that maps inode operations to the existing FileSystem class, presenting a read-only view of the in-memory file store.

Key changes:
- Added `fuse_adapter.h` and `fuse_adapter.cpp` under `include/utilities` and `src/utilities` respectively.
- Implemented FUSE operations:
    - `getattr`: Provides attributes for the root directory and files.
    - `readdir`: Lists files in the root directory. (Relies on a `known_files` list due to FileSystem limitations).
    - `open`: Allows read-only access to files.
    - `read`: Reads content from files.
- The adapter simulates a flat directory structure.
- A `main` function in `fuse_adapter.cpp` initializes `FileSystem`, populates it with test data, and starts the FUSE event loop.
- Updated the root `CMakeLists.txt` to:
    - Find the FUSE 3 library (using `pkg_check_modules`).
    - Add a new executable target `simpli_fuse_adapter`.
    - Link against `SimpliDFS_Utils`, `Threads::Threads`, and FUSE libraries.
    - Include the `_FILE_OFFSET_BITS=64` compile definition required by FUSE.

Testing Notes:
- The adapter compiles and mounts. `getattr` and basic file existence checks appear to function.
- During testing in an environment with libfuse 3.14.0, a "library too old" warning was observed from FUSE. Core operations like `readdir` and `read` were not dispatched to the adapter's handlers, resulting in "Function not implemented" errors for these commands. This suggests a FUSE library or environment compatibility issue rather than an error in the adapter's handler logic itself.