### PR TITLE
Fix: Improve `touch` utility compatibility

### DIFF
--- a/include/utilities/fuse_adapter.h
+++ b/include/utilities/fuse_adapter.h
@@ -26,5 +26,7 @@ int simpli_create(const char *path, mode_t mode, struct fuse_file_info *fi);
 int simpli_write(const char *path, const char *buf, size_t size, off_t offset, struct fuse_file_info *fi);
 int simpli_unlink(const char *path);
 int simpli_rename(const char *from, const char *to, unsigned int flags);
+int simpli_release(const char *path, struct fuse_file_info *fi); // Added release
+int simpli_utimens(const char *path, const struct timespec tv[2], struct fuse_file_info *fi); // Added utimens
 
 #endif // SIMPLIDFS_FUSE_ADAPTER_H


### PR DESCRIPTION
This commit addresses issues where the `touch` utility failed to work as expected with the FUSE filesystem. The problems affected both creating new files and updating timestamps of existing files.

The following changes were made:

1.  **`simpli_create` Modification**:
    *   The `simpli_create` function in `src/utilities/fuse_adapter.cpp`
      was updated to set `fi->fh = 1` (a dummy file handle) upon
      successful file creation. This is required by FUSE to signal
      that the `creat()` operation successfully "opened" the file.

2.  **`simpli_release` Handler Added**:
    *   A `simpli_release` function was added to `fuse_adapter.cpp`
      and registered. This function handles the `close()` operation
      that `touch` (and other utilities) perform after `creat()`.
      It currently logs invocation and returns success.

3.  **`simpli_utimens` Handler Added**:
    *   A `simpli_utimens` function was added to `fuse_adapter.cpp`
      and registered. This function handles requests to update file
      access and modification timestamps (e.g., when `touch` is used
      on an existing file).
    *   The current implementation is a stub: it logs the call and
      the requested timestamps, then returns success (0) without
      actually modifying any stored timestamps (as the underlying
      `FileSystem` model doesn't yet support this). This is sufficient
      to prevent `touch` from failing due to a missing handler.

4.  **Test Script Updates (`run_fuse_tests.sh`)**:
    *   Added specific test cases for `touch` on new files and
      `touch` on existing files.
    *   These tests verify the exit codes of `touch` and file listing commands.
    *   They also check the FUSE adapter's log for expected success
      messages from `simpli_create`, `simpli_release`, and
      `simpli_utimens`, providing more robust verification.

These changes should significantly improve the compatibility of the FUSE filesystem with standard utilities like `touch`.