### PR TITLE
feat: Add comprehensive network communication tests and initial refac…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,14 +122,26 @@ target_link_libraries(metaserver
 target_include_directories(metaserver PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 
-# Define the node executable
-add_executable(node src/node/node.cpp) 
-target_include_directories(node PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(node 
+# Define the SimpliDFS_NodeLib library
+add_library(SimpliDFS_NodeLib src/node/node.cpp)
+target_include_directories(SimpliDFS_NodeLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(SimpliDFS_NodeLib
+    PUBLIC # If Node.h includes headers from SimpliDFS_Utils that are needed by users of SimpliDFS_NodeLib
+    SimpliDFS_Utils
     PRIVATE
-    SimpliDFS_Utils # This is fine as SimpliDFS_Utils is a separate utility library
     Threads::Threads
 )
+
+# Define the node executable
+add_executable(node src/main_node.cpp) # Assuming a main_node.cpp for the executable
+target_link_libraries(node 
+    PRIVATE
+    SimpliDFS_NodeLib
+    # SimpliDFS_Utils and Threads::Threads are linked via SimpliDFS_NodeLib
+)
+# Ensure node executable can find headers if main_node.cpp needs them directly
+target_include_directories(node PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 
 # Define the FUSE adapter executable
 add_executable(simpli_fuse_adapter src/utilities/fuse_adapter.cpp)

--- a/include/utilities/filesystem.h
+++ b/include/utilities/filesystem.h
@@ -76,6 +76,13 @@ public:
      */
     std::string getXattr(const std::string& filename, const std::string& attrName);
 
+    /**
+     * @brief Checks if a file exists in the file system.
+     * @param _pFilename The name of the file to check.
+     * @return True if the file exists, false otherwise.
+     */
+    bool fileExists(const std::string& _pFilename) const;
+
 private:
     /**
      * @brief In-memory storage for files, mapping filename to its content (now binary).
@@ -87,7 +94,7 @@ private:
      * @brief Mutex to protect the _Files map, ensuring thread-safe access to file data.
      * All public methods acquire this mutex before accessing _Files.
      */
-    std::mutex _Mutex; 
+    mutable std::mutex _Mutex;
 };
 
 

--- a/src/main_node.cpp
+++ b/src/main_node.cpp
@@ -1,0 +1,65 @@
+#include "node/node.h"
+#include "utilities/logger.h"
+#include <string>
+#include <iostream>
+#include <stdexcept>
+#include <thread> // For std::this_thread::sleep_for
+#include <chrono> // For std::chrono::seconds
+
+int main(int argc, char* argv[]) {
+    if (argc < 3) {
+        std::cerr << "Usage: " << argv[0] << " <NodeName> <Port>" << std::endl;
+        return 1;
+    }
+
+    std::string nodeName = argv[1];
+    int port = 0;
+    try {
+        port = std::stoi(argv[2]);
+    } catch (const std::invalid_argument& ia) {
+        std::cerr << "Invalid port number: " << argv[2] << ". " << ia.what() << std::endl;
+        return 1;
+    } catch (const std::out_of_range& oor) {
+        std::cerr << "Port number out of range: " << argv[2] << ". " << oor.what() << std::endl;
+        return 1;
+    }
+
+    try {
+        Logger::init("node_" + nodeName + ".log", LogLevel::INFO);
+    } catch (const std::exception& e) {
+        std::cerr << "FATAL: Logger initialization failed for node " << nodeName << ": " << e.what() << std::endl;
+        return 1;
+    }
+
+    Logger::getInstance().log(LogLevel::INFO, "Node " + nodeName + " starting on port " + std::to_string(port));
+
+    try {
+        Node node(nodeName, port);
+        Logger::getInstance().log(LogLevel::INFO, "Node object '" + nodeName + "' created.");
+
+        node.start();
+        Logger::getInstance().log(LogLevel::INFO, "Node " + nodeName + " server started.");
+
+        // Register with the MetadataManager
+        // TODO: Make Metaserver address/port configurable
+        Logger::getInstance().log(LogLevel::INFO, "Node " + nodeName + " registering with MetadataManager at 127.0.0.1:50505.");
+        node.registerWithMetadataManager("127.0.0.1", 50505);
+        Logger::getInstance().log(LogLevel::INFO, "Node " + nodeName + " registration attempt completed.");
+
+        Logger::getInstance().log(LogLevel::INFO, "Node " + nodeName + " running. Main thread entering idle loop.");
+        while (true) {
+            std::this_thread::sleep_for(std::chrono::seconds(60));
+            Logger::getInstance().log(LogLevel::DEBUG, "Node " + nodeName + " main thread periodic wake up.");
+        }
+
+    } catch (const std::exception& e) {
+        Logger::getInstance().log(LogLevel::FATAL, "Unhandled exception in node " + nodeName + ": " + std::string(e.what()));
+        return 1;
+    } catch (...) {
+        Logger::getInstance().log(LogLevel::FATAL, "Unhandled non-standard exception in node " + nodeName + ".");
+        return 1;
+    }
+
+    Logger::getInstance().log(LogLevel::INFO, "Node " + nodeName + " shutting down (unexpectedly reached end of main).");
+    return 0;
+}

--- a/src/node/node.cpp
+++ b/src/node/node.cpp
@@ -1,73 +1,11 @@
-#include "node/node.h"
-#include "utilities/logger.h" // Include the Logger header
-#include <string>   // For std::string, std::stoi
-#include <iostream> // For std::cerr (though logger will replace most)
-#include <stdexcept> // For std::exception
+#include "node/node.h" // For Node class definition
+#include "utilities/filesystem.h" // For FileSystem operations
 
-// Assuming Node class methods like start() and registerWithMetadataManager()
-// would internally use Logger::getInstance() if they need logging.
-// This main function acts as the entry point for a node executable.
-
-int main(int argc, char* argv[]) {
-    if (argc < 3) {
-        // Logger might not be initialized yet, so use std::cerr for this specific early error.
-        std::cerr << "Usage: " << argv[0] << " <NodeName> <Port>" << std::endl;
-        return 1;
-    }
-
-    std::string nodeName = argv[1];
-    int port = 0;
-    try {
-        port = std::stoi(argv[2]);
-    } catch (const std::invalid_argument& ia) {
-        std::cerr << "Invalid port number: " << argv[2] << ". " << ia.what() << std::endl;
-        return 1;
-    } catch (const std::out_of_range& oor) {
-        std::cerr << "Port number out of range: " << argv[2] << ". " << oor.what() << std::endl;
-        return 1;
-    }
-
-    try {
-        // Initialize logger for this node. Each node will have its own log file.
-        Logger::init("node_" + nodeName + ".log", LogLevel::INFO);
-    } catch (const std::exception& e) {
-        // If logger init fails, this is a critical issue. Output to cerr.
-        std::cerr << "FATAL: Logger initialization failed for node " << nodeName << ": " << e.what() << std::endl;
-        return 1;
-    }
-
-    Logger::getInstance().log(LogLevel::INFO, "Node " + nodeName + " starting on port " + std::to_string(port));
-
-    try {
-        Node node(nodeName, port); // Assuming Node constructor might log
-        Logger::getInstance().log(LogLevel::INFO, "Node object '" + nodeName + "' created.");
-        
-        node.start(); // Assuming Node::start might log
-        Logger::getInstance().log(LogLevel::INFO, "Node " + nodeName + " started.");
-
-        // Register with the MetadataManager
-        // Replace "127.0.0.1" with actual MetadataManager IP if different
-        Logger::getInstance().log(LogLevel::INFO, "Node " + nodeName + " registering with MetadataManager at 127.0.0.1:50505.");
-        node.registerWithMetadataManager("127.0.0.1", 50505); 
-        Logger::getInstance().log(LogLevel::INFO, "Node " + nodeName + " registration attempt completed.");
-
-        // Keep the main thread running indefinitely
-        Logger::getInstance().log(LogLevel::INFO, "Node " + nodeName + " running. Main thread entering idle loop.");
-        while (true) {
-            // Add periodic tasks here if needed, e.g., sending heartbeats
-            // For now, just sleep.
-            std::this_thread::sleep_for(std::chrono::seconds(60)); // Sleep for a longer duration
-            Logger::getInstance().log(LogLevel::DEBUG, "Node " + nodeName + " main thread periodic wake up."); 
-        }
-
-    } catch (const std::exception& e) {
-        Logger::getInstance().log(LogLevel::FATAL, "Unhandled exception in node " + nodeName + ": " + std::string(e.what()));
-        return 1; // Indicate an error
-    } catch (...) {
-        Logger::getInstance().log(LogLevel::FATAL, "Unhandled non-standard exception in node " + nodeName + ".");
-        return 1; // Indicate an error
-    }
-    
-    Logger::getInstance().log(LogLevel::INFO, "Node " + nodeName + " shutting down (unexpectedly reached end of main).");
-    return 0;
+// Implementation for Node::checkFileExistsOnNode
+bool Node::checkFileExistsOnNode(const std::string& filename) const { // Made const again
+    // Calls the new FileSystem::fileExists method which is also const.
+    return fileSystem.fileExists(filename);
 }
+
+// To ensure this file is not empty if other methods are moved here later.
+// void Node::someOtherMethod() { /* ... */ }

--- a/src/utilities/filesystem.cpp
+++ b/src/utilities/filesystem.cpp
@@ -245,3 +245,8 @@ std::string FileSystem::getXattr(const std::string& filename, const std::string&
     // Logger::getInstance().log(LogLevel::INFO, "xattr not found for file: " + filename + ", Attribute: " + attrName);
     return "";
 }
+
+bool FileSystem::fileExists(const std::string& _pFilename) const {
+    std::lock_guard<std::mutex> lock(_Mutex); // _Mutex is now mutable in the header
+    return _Files.count(_pFilename);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(SimpliDFSTests
     logger_tests.cpp      # Added new logger tests file
     blockio_test.cpp      # Added blockio tests
     cid_tests.cpp         # Added CID conversion tests
+    integration_tests.cpp # Added new integration tests file
     # Removed direct compilation of utility sources:
     # ../../src/utilities/filesystem.cpp
     # ../../src/utilities/message.cpp
@@ -28,6 +29,7 @@ target_link_libraries(SimpliDFSTests
     Threads::Threads
     SimpliDFS_Utils # Link against common utilities library (now includes BlockIO)
     SimpliDFS_MetaServerLib # Link against the new metaserver library
+    SimpliDFS_NodeLib       # Link against the new node library
 )
 
 # Include directories for the headers

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -1,0 +1,278 @@
+#include "gtest/gtest.h"
+#include <thread>
+#include <vector>
+#include <string>
+#include <atomic>
+#include <mutex>
+#include <condition_variable>
+#include <sstream> // For std::stringstream
+
+#include "metaserver/metaserver.h"
+#include "node/node.h"
+#include "utilities/message.h"
+#include "utilities/client.h"
+#include "utilities/server.h"
+#include "utilities/filesystem.h" // Though Node manages its own FS
+#include "utilities/logger.h"
+#include "utilities/networkexception.h" // For try-catch blocks
+
+// Define unique ports for the test
+const int METASERVER_PORT_INTEGRATION = 12360;
+const int NODE1_PORT_INTEGRATION = 12361;
+const int NODE2_PORT_INTEGRATION = 12362; // If using a second node
+const int FUSE_SIM_CLIENT_PORT_INTEGRATION = 12363; // Not strictly needed, client connects
+
+class IntegrationTest : public ::testing::Test {
+protected:
+    MetadataManager metadataManager; // Each test gets its own manager
+
+    // Synchronization primitives
+    std::mutex mtx;
+    std::condition_variable cv;
+    std::atomic<int> nodesRegistered{0};
+    std::atomic<bool> fuseRequestProcessed{false};
+    std::atomic<int> nodeFilesCreated{0};
+    std::string fileCreationTargetNodeId; // To store which node was selected
+
+    void SetUp() override {
+        try {
+            Logger::init("integration_tests.log", LogLevel::DEBUG);
+        } catch (const std::exception& e) {
+            // Log or handle if init fails
+        }
+        nodesRegistered = 0;
+        fuseRequestProcessed = false;
+        nodeFilesCreated = 0;
+        fileCreationTargetNodeId.clear();
+    }
+
+    void TearDown() override {
+        // Cleanup any static or global states if necessary, though instance members are preferred
+        try {
+            Logger::init("dummy_integration_cleanup.log", LogLevel::DEBUG); // Reset logger to avoid interference
+            std::remove("dummy_integration_cleanup.log");
+            std::remove("dummy_integration_cleanup.log.1");
+        } catch (const std::runtime_error& e) { /* ignore */ }
+        std::remove("integration_tests.log");
+        for (int i = 1; i <= 5; ++i) { // Clean up potential rotated logs
+             std::remove(("integration_tests.log." + std::to_string(i)).c_str());
+        }
+    }
+};
+
+TEST_F(IntegrationTest, EndToEndFileCreation) {
+    Logger::getInstance().log(LogLevel::INFO, "Starting EndToEndFileCreation test.");
+
+    // --- 1. Start Metaserver Listener Thread ---
+    Networking::Server metaserverListener(METASERVER_PORT_INTEGRATION);
+    ASSERT_TRUE(metaserverListener.InitServer());
+    std::thread metaserverThread([&]() {
+        Logger::getInstance().log(LogLevel::INFO, "Metaserver listener thread started.");
+        int connectionCount = 0; // Expecting 1 node registration + 1 FUSE request initially
+
+        // For this test, let's assume a specific number of interactions to simplify shutdown.
+        // A real server would loop indefinitely.
+        while (connectionCount < 2 && metaserverListener.ServerIsRunning()) {
+            try {
+                Networking::ClientConnection conn = metaserverListener.Accept();
+                if (!metaserverListener.ServerIsRunning()) break;
+
+                std::vector<char> data = metaserverListener.Receive(conn);
+                if (data.empty()) {
+                    Logger::getInstance().log(LogLevel::WARN, "Metaserver received empty data.");
+                    metaserverListener.DisconnectClient(conn);
+                    continue;
+                }
+                Message reqMsg = Message::Deserialize(std::string(data.begin(), data.end()));
+                connectionCount++;
+
+                if (reqMsg._Type == MessageType::RegisterNode) {
+                    Logger::getInstance().log(LogLevel::INFO, "Metaserver: Received RegisterNode from " + reqMsg._Filename);
+                    metadataManager.registerNode(reqMsg._Filename, reqMsg._NodeAddress, reqMsg._NodePort);
+
+                    Message ackMsg; // Send simple ack
+                    ackMsg._Type = MessageType::RegisterNode; // Echo type
+                    ackMsg._ErrorCode = 0;
+                    metaserverListener.Send(Message::Serialize(ackMsg).c_str(), conn);
+                    {
+                        std::lock_guard<std::mutex> lg(mtx);
+                        nodesRegistered++;
+                    }
+                    cv.notify_all();
+                } else if (reqMsg._Type == MessageType::CreateFile) {
+                    Logger::getInstance().log(LogLevel::INFO, "Metaserver: Received CreateFile for " + reqMsg._Path + " mode " + std::to_string(reqMsg._Mode));
+                    std::string filename = reqMsg._Path; // Assuming path is like "/file.txt"
+                    if (filename.rfind('/', 0) == 0) { // Starts with '/'
+                        filename = filename.substr(1); // Remove leading '/' for internal use
+                    }
+
+                    // Metaserver logic: add file, select node(s)
+                    int addFileRes = metadataManager.addFile(filename, {}, reqMsg._Mode);
+                    Message fuseRespMsg;
+                    fuseRespMsg._Type = MessageType::FileCreated; // Or CreateFileResponse
+                    fuseRespMsg._Path = reqMsg._Path;
+
+                    if (addFileRes == 0) {
+                        std::vector<std::string> targetNodeIds = metadataManager.getFileNodes(filename);
+                        ASSERT_FALSE(targetNodeIds.empty()) << "addFile succeeded but no nodes assigned.";
+                        fileCreationTargetNodeId = targetNodeIds[0]; // Simplification: use the first node
+
+                        Logger::getInstance().log(LogLevel::INFO, "Metaserver: File " + filename + " assigned to node " + fileCreationTargetNodeId);
+
+                        // Metaserver instructs Node to create the file (empty write)
+                        try {
+                            std::string nodeFullAddress = metadataManager.getNodeInfo(fileCreationTargetNodeId).nodeAddress;
+                            std::string nodeIp = nodeFullAddress.substr(0, nodeFullAddress.find(':'));
+                            int nodeInternalPort = std::stoi(nodeFullAddress.substr(nodeFullAddress.find(':') + 1));
+
+                            Networking::Client clientToNode(nodeIp.c_str(), nodeInternalPort);
+                            ASSERT_TRUE(clientToNode.IsConnected());
+
+                            Message createFileOrderToNode;
+                            createFileOrderToNode._Type = MessageType::WriteFile; // Using WriteFile for create
+                            createFileOrderToNode._Filename = filename;
+                            createFileOrderToNode._Content = ""; // Empty content for creation
+
+                            clientToNode.Send(Message::Serialize(createFileOrderToNode).c_str());
+                            std::vector<char> nodeResponseRaw = clientToNode.Receive();
+                            // Node sends string "File ... written successfully."
+                            std::string nodeResponseStr(nodeResponseRaw.begin(), nodeResponseRaw.end());
+                            Logger::getInstance().log(LogLevel::INFO, "Metaserver: Response from Node " + fileCreationTargetNodeId + " for create: " + nodeResponseStr);
+
+                            if (nodeResponseStr.find("successfully") != std::string::npos) {
+                                fuseRespMsg._ErrorCode = 0; // Success
+                                {
+                                    std::lock_guard<std::mutex> lg(mtx);
+                                    nodeFilesCreated++;
+                                }
+                                cv.notify_all();
+                            } else {
+                                fuseRespMsg._ErrorCode = -1; // Generic error from node
+                            }
+                            clientToNode.Disconnect();
+                        } catch (const std::exception& e) {
+                            Logger::getInstance().log(LogLevel::ERROR, "Metaserver: Failed to command node " + fileCreationTargetNodeId + ": " + e.what());
+                            fuseRespMsg._ErrorCode = -1; // Error communicating with node
+                        }
+                    } else {
+                        fuseRespMsg._ErrorCode = addFileRes; // Propagate error from addFile
+                    }
+                    metaserverListener.Send(Message::Serialize(fuseRespMsg).c_str(), conn);
+                    {
+                        std::lock_guard<std::mutex> lg(mtx);
+                        fuseRequestProcessed = true;
+                    }
+                    cv.notify_all();
+                }
+                metaserverListener.DisconnectClient(conn);
+            } catch (const Networking::NetworkException& ne) {
+                if (!metaserverListener.ServerIsRunning()) {
+                    Logger::getInstance().log(LogLevel::INFO, "Metaserver listener shutting down due to NetworkException (likely intended).");
+                    break;
+                }
+                Logger::getInstance().log(LogLevel::ERROR, "Metaserver listener NetworkException: " + std::string(ne.what()));
+            } catch (const std::exception& e) {
+                Logger::getInstance().log(LogLevel::ERROR, "Metaserver listener std::exception: " + std::string(e.what()));
+            }
+        }
+        Logger::getInstance().log(LogLevel::INFO, "Metaserver listener thread finished.");
+    });
+
+    // --- 2. Start Node(s) ---
+    // Node's constructor takes (name, port). Node::start() starts its server.
+    Node node1("node1", NODE1_PORT_INTEGRATION);
+    node1.start(); // Starts listening in a separate thread managed by Node
+    Logger::getInstance().log(LogLevel::INFO, "Node1 started.");
+
+    // --- 3. Register Node(s) with Metaserver ---
+    Logger::getInstance().log(LogLevel::INFO, "Node1 attempting to register.");
+    node1.registerWithMetadataManager("127.0.0.1", METASERVER_PORT_INTEGRATION);
+
+    {
+        std::unique_lock<std::mutex> lk(mtx);
+        ASSERT_TRUE(cv.wait_for(lk, std::chrono::seconds(5), [&]{ return nodesRegistered.load() >= 1; }))
+            << "Node1 did not register with Metaserver in time.";
+    }
+    Logger::getInstance().log(LogLevel::INFO, "Node1 registration confirmed by Metaserver.");
+    ASSERT_TRUE(metadataManager.isNodeRegistered("node1"));
+
+    // --- 4. Simulate FUSE Client Creating a File ---
+    const std::string testFilename = "/newfile.txt";
+    const std::string internalFilename = "newfile.txt"; // Path as stored in Metaserver/Node
+    const uint32_t testMode = 0100644;
+    Message fuseResponse;
+
+    try {
+        Logger::getInstance().log(LogLevel::INFO, "FUSE Client: Attempting to create " + testFilename);
+        Networking::Client fuseClient("127.0.0.1", METASERVER_PORT_INTEGRATION);
+        ASSERT_TRUE(fuseClient.IsConnected());
+
+        Message createFileMsg;
+        createFileMsg._Type = MessageType::CreateFile;
+        createFileMsg._Path = testFilename; // FUSE client sends full path
+        createFileMsg._Mode = testMode;
+
+        fuseClient.Send(Message::Serialize(createFileMsg).c_str());
+        std::vector<char> respData = fuseClient.Receive();
+        ASSERT_FALSE(respData.empty());
+        fuseResponse = Message::Deserialize(std::string(respData.begin(), respData.end()));
+        fuseClient.Disconnect();
+    } catch (const std::exception& e) {
+        FAIL() << "FUSE Client simulation failed: " << e.what();
+    }
+
+    {
+        std::unique_lock<std::mutex> lk(mtx);
+        ASSERT_TRUE(cv.wait_for(lk, std::chrono::seconds(10), [&]{ return fuseRequestProcessed.load(); }))
+            << "Metaserver did not process FUSE request in time.";
+        ASSERT_TRUE(cv.wait_for(lk, std::chrono::seconds(5), [&]{ return nodeFilesCreated.load() >=1; }))
+            << "Node did not confirm file creation in time.";
+    }
+    Logger::getInstance().log(LogLevel::INFO, "FUSE Client: Received response from Metaserver.");
+
+    // --- 5. Verifications ---
+    // a. FUSE client receives success
+    ASSERT_EQ(fuseResponse._Type, MessageType::FileCreated); // Or CreateFileResponse
+    ASSERT_EQ(fuseResponse._ErrorCode, 0) << "FUSE client did not receive success for CreateFile. Error: " << fuseResponse._ErrorCode;
+    ASSERT_EQ(fuseResponse._Path, testFilename);
+
+    // b. MetadataManager has correct metadata
+    ASSERT_TRUE(metadataManager.fileExists(internalFilename));
+    uint32_t mode, uid, gid;
+    uint64_t size;
+    ASSERT_EQ(metadataManager.getFileAttributes(internalFilename, mode, uid, gid, size), 0);
+    ASSERT_EQ(mode, testMode);
+
+    std::vector<std::string> fileNodes = metadataManager.getFileNodes(internalFilename);
+    ASSERT_FALSE(fileNodes.empty());
+    ASSERT_EQ(fileNodes[0], fileCreationTargetNodeId); // Check if the correct node was used.
+    ASSERT_EQ(fileNodes[0], "node1"); // In this single-node test, it must be node1.
+
+
+    // c. File exists on the selected Node's filesystem
+    ASSERT_FALSE(fileCreationTargetNodeId.empty());
+    if (fileCreationTargetNodeId == "node1") {
+        ASSERT_TRUE(node1.checkFileExistsOnNode(internalFilename))
+            << "File " << internalFilename << " does not exist on node1's filesystem.";
+        // Optionally, check content if it were non-empty write
+        // std::string contentOnNode = node1.fileSystem.readFile(internalFilename);
+        // ASSERT_TRUE(contentOnNode.empty());
+    } else {
+        FAIL() << "File assigned to unexpected node: " << fileCreationTargetNodeId;
+    }
+
+    // --- 6. Shutdown ---
+    Logger::getInstance().log(LogLevel::INFO, "Shutting down Metaserver listener.");
+    metaserverListener.Shutdown(); // This should make the Accept() in metaserverThread return/throw
+    if (metaserverThread.joinable()) {
+        metaserverThread.join();
+    }
+    Logger::getInstance().log(LogLevel::INFO, "Metaserver listener thread joined.");
+
+    // Node's server is shut down by its own destructor or a specific stop method if implemented.
+    // For this test, Node's destructor should handle its thread if Node::start() detaches.
+    // If Node::start() joins, it would have blocked. Node::start() detaches its threads.
+    // We might need an explicit node1.stop() if it exists, or rely on test teardown.
+    // The Node class in the project doesn't seem to have an explicit stop, relies on its server object's lifecycle.
+    Logger::getInstance().log(LogLevel::INFO, "EndToEndFileCreation test completed.");
+}

--- a/tests/networking_tests.cpp
+++ b/tests/networking_tests.cpp
@@ -9,6 +9,9 @@
 #include "utilities/logger.h" // Add this include
 #include <cstdio>   // For std::remove
 #include <string>   // For std::to_string in TearDown
+#include "metaserver/metaserver.h" // For MetadataManager
+#include "node/node.h"             // For Node
+#include "utilities/message.h"     // For Message, MessageType
 
 // Basic test fixture for networking tests if needed, or just use TEST directly.
 class NetworkingTest : public ::testing::Test {
@@ -140,12 +143,24 @@ TEST_F(NetworkingTest, MultipleClientsConnect) { // Changed to TEST_F
     const int numClients = 5;
     std::atomic<int> connectedClients{0};
 
+#include <sstream> // Required for std::stringstream
+
+// ... (other includes)
+
     std::thread serverAcceptThread([&]() {
         for (int i = 0; i < numClients; ++i) {
-            Networking::ClientConnection c = server.Accept();
-            ASSERT_TRUE(c.clientSocket != 0);
-            server.DisconnectClient(c);
-            connectedClients++;
+            try {
+                Networking::ClientConnection c = server.Accept();
+                ASSERT_TRUE(c.clientSocket != 0);
+                server.DisconnectClient(c);
+                connectedClients++;
+            } catch (const Networking::NetworkException& e) {
+                // Server might have been shut down, log and break
+                std::stringstream ss;
+                ss << "NetworkException in serverAcceptThread: " << e.what();
+                Logger::getInstance().log(LogLevel::ERROR, ss.str());
+                break;
+            }
         }
     });
     std::this_thread::sleep_for(std::chrono::milliseconds(200)); // Ensure server is listening
@@ -172,4 +187,334 @@ TEST_F(NetworkingTest, MultipleClientsConnect) { // Changed to TEST_F
     if (serverAcceptThread.joinable()) serverAcceptThread.join(); // Join instead of detach
     server.Shutdown();
     ASSERT_EQ(connectedClients, numClients);
+}
+
+TEST_F(NetworkingTest, NodeRegistrationWithMetadataManager) {
+    const int metaserverPort = 12350;
+    MetadataManager metadataManager; // Metaserver logic instance
+
+    Networking::Server metaserverNetworkListener(metaserverPort);
+    ASSERT_TRUE(metaserverNetworkListener.InitServer());
+
+    std::atomic<bool> registrationDone{false};
+    std::string registeredNodeId;
+
+    std::thread serverThread([&]() {
+        try {
+            std::stringstream log_msg_start;
+            log_msg_start << "Metaserver listener started on port " << metaserverPort;
+            Logger::getInstance().log(LogLevel::INFO, log_msg_start.str());
+
+            Networking::ClientConnection nodeConnection = metaserverNetworkListener.Accept();
+            ASSERT_TRUE(nodeConnection.clientSocket != 0);
+            Logger::getInstance().log(LogLevel::INFO, "Metaserver accepted connection for registration");
+
+            std::vector<char> data = metaserverNetworkListener.Receive(nodeConnection);
+            ASSERT_FALSE(data.empty());
+            std::string receivedStr(data.begin(), data.end());
+            Message msg = Message::Deserialize(receivedStr);
+
+            ASSERT_EQ(msg._Type, MessageType::RegisterNode);
+            if (msg._Type == MessageType::RegisterNode) {
+                std::stringstream reg_log_msg;
+                reg_log_msg << "Metaserver received RegisterNode message for Node: " << msg._Filename
+                            << " on address: " << msg._NodeAddress << ":" << msg._NodePort;
+                Logger::getInstance().log(LogLevel::INFO, reg_log_msg.str());
+
+                metadataManager.registerNode(msg._Filename, msg._NodeAddress, msg._NodePort);
+                registeredNodeId = msg._Filename; // Store the node ID
+                // Send a simple success response
+                metaserverNetworkListener.Send("Registered", nodeConnection);
+                registrationDone = true;
+            } else {
+                std::stringstream err_log_msg;
+                err_log_msg << "Metaserver received unexpected message type: " << static_cast<int>(msg._Type);
+                Logger::getInstance().log(LogLevel::ERROR, err_log_msg.str());
+                metaserverNetworkListener.Send("Error: Unexpected message type", nodeConnection);
+            }
+            metaserverNetworkListener.DisconnectClient(nodeConnection);
+            Logger::getInstance().log(LogLevel::INFO, "Metaserver processed registration and disconnected client.");
+        } catch (const Networking::NetworkException& e) {
+            std::stringstream ss_err;
+            ss_err << "Metaserver listener thread NetworkException: " << e.what();
+            Logger::getInstance().log(LogLevel::ERROR, ss_err.str());
+        } catch (const std::exception& e) {
+            std::stringstream ss_err;
+            ss_err << "Metaserver listener thread std::exception: " << e.what();
+            Logger::getInstance().log(LogLevel::ERROR, ss_err.str());
+        }
+        // Server will be shut down by the main thread
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100)); // Give server thread time to start listening
+
+    const std::string nodeName = "testNode1";
+    // Node's internal server port is different from metaserver's listening port
+    Node testNode(nodeName, 12351);
+    // The Node::start() method starts its own server and heartbeat thread.
+    // For this test, we only need to test registration, so we don't call testNode.start().
+    // We directly call registerWithMetadataManager.
+
+    std::stringstream node_reg_log;
+    node_reg_log << "Node " << nodeName << " attempting to register with Metaserver on port " << metaserverPort;
+    Logger::getInstance().log(LogLevel::INFO, node_reg_log.str());
+    testNode.registerWithMetadataManager("127.0.0.1", metaserverPort);
+
+    // Wait for registration to be processed
+    int waitRetries = 0;
+    while(!registrationDone.load() && waitRetries < 100) { // Max 10 seconds
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        waitRetries++;
+    }
+
+    ASSERT_TRUE(registrationDone.load()) << "Registration was not completed in time.";
+    ASSERT_TRUE(metadataManager.isNodeRegistered(nodeName)) << "Node " << nodeName << " was not found in MetadataManager.";
+    ASSERT_EQ(registeredNodeId, nodeName) << "The Node ID registered does not match the expected Node ID.";
+
+    Logger::getInstance().log(LogLevel::INFO, "Assertions passed. Shutting down server.");
+    metaserverNetworkListener.Shutdown();
+    if (serverThread.joinable()) {
+        serverThread.join();
+    }
+    Logger::getInstance().log(LogLevel::INFO, "Test NodeRegistrationWithMetadataManager completed.");
+}
+
+TEST_F(NetworkingTest, NodeHeartbeatProcessing) {
+    const int metaserverPort = 12352; // Different port for this test
+    MetadataManager metadataManager;
+    const std::string nodeId = "heartbeatNode";
+    const std::string nodeAddr = "127.0.0.1";
+    const int nodePort = 7777;
+
+    // 1. Pre-register the node
+    metadataManager.registerNode(nodeId, nodeAddr, nodePort);
+    NodeInfo initialNodeInfo = metadataManager.getNodeInfo(nodeId);
+    ASSERT_TRUE(initialNodeInfo.isAlive);
+    time_t initialHeartbeatTime = initialNodeInfo.lastHeartbeat;
+
+    // Small delay to ensure subsequent heartbeat time is different
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    // 2. Setup server to listen for heartbeat
+    Networking::Server metaserverNetworkListener(metaserverPort);
+    ASSERT_TRUE(metaserverNetworkListener.InitServer());
+    std::atomic<bool> heartbeatProcessed{false};
+
+    std::thread serverThread([&]() {
+        try {
+            std::stringstream log_msg_start;
+            log_msg_start << "Heartbeat listener started on port " << metaserverPort;
+            Logger::getInstance().log(LogLevel::INFO, log_msg_start.str());
+
+            Networking::ClientConnection nodeConnection = metaserverNetworkListener.Accept();
+            ASSERT_TRUE(nodeConnection.clientSocket != 0);
+            Logger::getInstance().log(LogLevel::INFO, "Heartbeat listener accepted connection.");
+
+            std::vector<char> data = metaserverNetworkListener.Receive(nodeConnection);
+            ASSERT_FALSE(data.empty());
+            std::string receivedStr(data.begin(), data.end());
+            Message msg = Message::Deserialize(receivedStr);
+
+            ASSERT_EQ(msg._Type, MessageType::Heartbeat);
+            if (msg._Type == MessageType::Heartbeat) {
+                std::stringstream hb_log_msg;
+                hb_log_msg << "Heartbeat listener received Heartbeat message for Node: " << msg._Filename;
+                Logger::getInstance().log(LogLevel::INFO, hb_log_msg.str());
+                ASSERT_EQ(msg._Filename, nodeId); // Ensure heartbeat is from the correct node
+
+                metadataManager.processHeartbeat(msg._Filename);
+                metaserverNetworkListener.Send("HeartbeatProcessed", nodeConnection);
+                heartbeatProcessed = true;
+            } else {
+                std::stringstream err_log_msg;
+                err_log_msg << "Heartbeat listener received unexpected message type: " << static_cast<int>(msg._Type);
+                Logger::getInstance().log(LogLevel::ERROR, err_log_msg.str());
+                metaserverNetworkListener.Send("Error: Unexpected message type for heartbeat", nodeConnection);
+            }
+            metaserverNetworkListener.DisconnectClient(nodeConnection);
+        } catch (const Networking::NetworkException& e) {
+            std::stringstream ss_err;
+            ss_err << "Heartbeat listener thread NetworkException: " << e.what();
+            Logger::getInstance().log(LogLevel::ERROR, ss_err.str());
+        } catch (const std::exception& e) {
+            std::stringstream ss_err;
+            ss_err << "Heartbeat listener thread std::exception: " << e.what();
+            Logger::getInstance().log(LogLevel::ERROR, ss_err.str());
+        }
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100)); // Give server thread time to start
+
+    // 3. Simulate Node sending a heartbeat
+    try {
+        Networking::Client heartbeatClient(nodeAddr.c_str(), metaserverPort); // Connect to our listener
+        ASSERT_TRUE(heartbeatClient.IsConnected());
+
+        Message heartbeatMsg;
+        heartbeatMsg._Type = MessageType::Heartbeat;
+        heartbeatMsg._Filename = nodeId; // Node identifier is sent in _Filename field for heartbeats
+
+        std::string serializedMsg = Message::Serialize(heartbeatMsg);
+        heartbeatClient.Send(serializedMsg.c_str());
+
+        // Wait for server to process and send response
+        std::vector<char> response = heartbeatClient.Receive();
+        ASSERT_FALSE(response.empty());
+        std::string responseStr(response.begin(), response.end());
+        ASSERT_EQ(responseStr, "HeartbeatProcessed");
+
+        heartbeatClient.Disconnect();
+    } catch (const Networking::NetworkException& e) {
+        FAIL() << "Heartbeat client failed with NetworkException: " << e.what();
+    }
+
+
+    // Wait for heartbeat to be processed by server thread
+    int waitRetries = 0;
+    while(!heartbeatProcessed.load() && waitRetries < 50) { // Max 5 seconds
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        waitRetries++;
+    }
+    ASSERT_TRUE(heartbeatProcessed.load()) << "Heartbeat was not processed in time.";
+
+    // 4. Verify heartbeat update
+    NodeInfo updatedNodeInfo = metadataManager.getNodeInfo(nodeId);
+    ASSERT_TRUE(updatedNodeInfo.isAlive);
+    ASSERT_GT(updatedNodeInfo.lastHeartbeat, initialHeartbeatTime) << "Last heartbeat time did not update.";
+
+    // Shutdown
+    Logger::getInstance().log(LogLevel::INFO, "Heartbeat test assertions passed. Shutting down server.");
+    metaserverNetworkListener.Shutdown();
+    if (serverThread.joinable()) {
+        serverThread.join();
+    }
+    Logger::getInstance().log(LogLevel::INFO, "Test NodeHeartbeatProcessing completed.");
+}
+
+TEST_F(NetworkingTest, FuseGetattrSimulation) {
+    const int metaserverPort = 12353; // Yet another unique port
+    MetadataManager metadataManager;
+
+    const std::string testFilePath = "/testfile.txt";
+    const uint32_t testFileMode = 0100644; // S_IFREG | 0644
+    const uint64_t testFileSize = 0; // Default size after addFile if not set otherwise
+    const uint32_t expectedUid = 0; // As per MetadataManager::getFileAttributes
+    const uint32_t expectedGid = 0; // As per MetadataManager::getFileAttributes
+
+    // 1. Pre-populate file metadata
+    // Register a dummy node so that addFile can succeed.
+    metadataManager.registerNode("testnode0", "127.0.0.1", 1234);
+
+    // Now add the file.
+    int addFileResult = metadataManager.addFile(testFilePath, {}, testFileMode);
+    ASSERT_EQ(addFileResult, 0) << "addFile failed during test setup. Error code: " << addFileResult;
+    // fileSizes[testFilePath] should be 0 by default from addFile.
+
+    // 2. Setup server to listen for FUSE GetAttr request
+    Networking::Server metaserverNetworkListener(metaserverPort);
+    ASSERT_TRUE(metaserverNetworkListener.InitServer());
+    std::atomic<bool> requestProcessed{false};
+
+    std::thread serverThread([&]() {
+        try {
+            std::stringstream log_msg_start;
+            log_msg_start << "FUSE GetAttr listener started on port " << metaserverPort;
+            Logger::getInstance().log(LogLevel::INFO, log_msg_start.str());
+
+            Networking::ClientConnection fuseAdapterConnection = metaserverNetworkListener.Accept();
+            ASSERT_TRUE(fuseAdapterConnection.clientSocket != 0);
+            Logger::getInstance().log(LogLevel::INFO, "FUSE GetAttr listener accepted connection.");
+
+            std::vector<char> data = metaserverNetworkListener.Receive(fuseAdapterConnection);
+            ASSERT_FALSE(data.empty());
+            Message reqMsg = Message::Deserialize(std::string(data.begin(), data.end()));
+
+            ASSERT_EQ(reqMsg._Type, MessageType::GetAttr);
+            if (reqMsg._Type == MessageType::GetAttr) {
+                Logger::getInstance().log(LogLevel::INFO, "FUSE GetAttr listener received GetAttr request for path: " + reqMsg._Path);
+                ASSERT_EQ(reqMsg._Path, testFilePath);
+
+                uint32_t mode, uid, gid;
+                uint64_t size;
+                int res = metadataManager.getFileAttributes(reqMsg._Path, mode, uid, gid, size);
+
+                Message respMsg;
+                respMsg._Type = MessageType::GetAttrResponse;
+                respMsg._Path = reqMsg._Path;
+                respMsg._ErrorCode = res; // e.g., 0 for success, -ENOENT for not found
+                if (res == 0) {
+                    respMsg._Mode = mode;
+                    respMsg._Uid = uid;
+                    respMsg._Gid = gid;
+                    respMsg._Size = size;
+                }
+
+                metaserverNetworkListener.Send(Message::Serialize(respMsg).c_str(), fuseAdapterConnection);
+                requestProcessed = true;
+            } else {
+                Logger::getInstance().log(LogLevel::ERROR, "FUSE GetAttr listener received unexpected message type.");
+                // Consider sending an error response back too
+            }
+            metaserverNetworkListener.DisconnectClient(fuseAdapterConnection);
+        } catch (const std::exception& e) { // Catching std::exception for broader coverage
+            std::stringstream ss_err;
+            ss_err << "FUSE GetAttr listener thread exception: " << e.what();
+            Logger::getInstance().log(LogLevel::ERROR, ss_err.str());
+            requestProcessed = true; // Allow main thread to proceed and fail assertions if this was unexpected
+        }
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100)); // Give server thread time to start
+
+    // 3. Simulate FUSE adapter client sending request
+    Message receivedRespMsg;
+    bool clientError = false;
+    try {
+        Networking::Client fuseClient("127.0.0.1", metaserverPort);
+        ASSERT_TRUE(fuseClient.IsConnected());
+
+        Message getattrReqMsg;
+        getattrReqMsg._Type = MessageType::GetAttr;
+        getattrReqMsg._Path = testFilePath; // Using _Path as per message.h for new FUSE types
+
+        fuseClient.Send(Message::Serialize(getattrReqMsg).c_str());
+
+        std::vector<char> responseData = fuseClient.Receive();
+        ASSERT_FALSE(responseData.empty());
+        receivedRespMsg = Message::Deserialize(std::string(responseData.begin(), responseData.end()));
+
+        fuseClient.Disconnect();
+    } catch (const Networking::NetworkException& e) {
+        FAIL() << "FUSE client failed with NetworkException: " << e.what();
+        clientError = true;
+    } catch (const std::exception& e) {
+        FAIL() << "FUSE client failed with std::exception: " << e.what();
+        clientError = true;
+    }
+    ASSERT_FALSE(clientError);
+
+
+    int waitRetries = 0;
+    while(!requestProcessed.load() && waitRetries < 50) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        waitRetries++;
+    }
+    ASSERT_TRUE(requestProcessed.load()) << "GetAttr request was not processed by server in time.";
+
+    // 4. Verify response
+    ASSERT_EQ(receivedRespMsg._Type, MessageType::GetAttrResponse);
+    ASSERT_EQ(receivedRespMsg._ErrorCode, 0); // Expect success
+    ASSERT_EQ(receivedRespMsg._Path, testFilePath);
+    ASSERT_EQ(receivedRespMsg._Mode, testFileMode);
+    ASSERT_EQ(receivedRespMsg._Uid, expectedUid);
+    ASSERT_EQ(receivedRespMsg._Gid, expectedGid);
+    ASSERT_EQ(receivedRespMsg._Size, testFileSize); // Expecting 0 as per current understanding of addFile/getFileAttributes
+
+    // Shutdown
+    Logger::getInstance().log(LogLevel::INFO, "FUSE GetAttr test assertions passed. Shutting down server.");
+    metaserverNetworkListener.Shutdown();
+    if (serverThread.joinable()) {
+        serverThread.join();
+    }
+    Logger::getInstance().log(LogLevel::INFO, "Test FuseGetattrSimulation completed.");
 }


### PR DESCRIPTION
…toring

This commit introduces several enhancements to test network communication between the Metaserver, Nodes, and FUSE adapter, and begins a refactoring of the networking utilities.

New Tests:
- I added unit tests to `networking_tests.cpp` for:
  - Node registration with MetadataManager.
  - Node heartbeat processing.
  - FUSE adapter `getattr` simulation.
- I created `integration_tests.cpp` with an end-to-end file creation scenario, testing interactions between a FUSE client (mocked), Metaserver, and a Node.
- I refactored `Node`, `FileSystem`, and `CMakeLists.txt` to support these tests.

Networking Refactoring (Partial and Incomplete):
- I began refactoring `Networking::Client` and `Networking::Server` for more robust, exception-based error handling.
- `Networking::Client` (`client.h`, `client.cpp`) is partially refactored.
- The interface for `Networking::Server` (`server.h`) has been updated.
- **Known Issue:** I could NOT update the implementation of `Networking::Server` in `src/utilities/server.cpp` due to persistent tooling failures. This leaves `server.cpp` inconsistent with `server.h`. As a result, `Node` class methods and dependent test cases have not been updated to reflect the new networking error handling model.

Further work is required to complete the networking refactoring, particularly for `server.cpp` and then propagating those changes through the `Node` class and relevant tests.