### PR TITLE
Add IPv6 support to server binding

### DIFF
--- a/include/utilities/server.h
+++ b/include/utilities/server.h
@@ -158,7 +158,8 @@ WSADATA wsaData; // Should this be a pointer or handled per InitServer call?
 	#endif
 addrinfo addressInfo; // Used for socket creation hints
 SOCKET serverSocket = 0; // Listening socket, initialize to 0 or INVALIDSOCKET_CONST
-sockaddr_in serverInfo;  // For IPv4 // TODO: support sockaddr_in6 for IPv6 with serverType_
+sockaddr_in serverInfo;  // Used for IPv4
+sockaddr_in6 serverInfo6; // Used when serverType_ == ServerType::IPv6
 bool serverIsConnected = false;
 std::vector<Networking::ClientConnection> clients;
 mutable std::mutex clients_mutex_; // Added mutable mutex for getClients() const


### PR DESCRIPTION
## Summary
- enable IPv6 binding when `ServerType::IPv6`
- store IPv6 address info in `serverInfo6`
- select sockaddr struct in BindSocket and GetPort

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure -VV`

------
https://chatgpt.com/codex/tasks/task_e_6840af6846048328b2fa351842699190