### PR TITLE
Add dependency setup script

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -64,13 +64,17 @@ Significant progress has been made on core distributed file system logic:
    git clone https://github.com/JacobBorden/SimpliDFS.git
    cd SimpliDFS
    ```
-2. Create a build directory and run CMake:
+2. Run the setup script to install dependencies:
+   ```sh
+   ./setup_dependencies.sh
+   ```
+3. Create a build directory and run CMake:
    ```sh
    mkdir build && cd build
    cmake ..
    make
    ```
-3. Run the tests:
+4. Run the tests:
    ```sh
    ./test/SimpliDFSTests
    ```

--- a/setup_dependencies.sh
+++ b/setup_dependencies.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# Install core packages
+sudo apt-get update -y
+sudo apt-get install -y libsodium-dev libzstd-dev pkg-config \
+    build-essential cmake meson ninja-build libudev-dev curl git
+
+# Install libfuse3 from source if pkg-config cannot find it
+if ! pkg-config --exists fuse3; then
+    FUSE_VERSION="3.16.2"
+    echo "Installing libfuse ${FUSE_VERSION} from source..."
+    curl -L -o fuse-${FUSE_VERSION}.tar.gz \
+        https://github.com/libfuse/libfuse/releases/download/fuse-${FUSE_VERSION}/fuse-${FUSE_VERSION}.tar.gz
+    tar xzf fuse-${FUSE_VERSION}.tar.gz
+    cd fuse-${FUSE_VERSION}
+    meson setup build --prefix=/usr
+    ninja -C build
+    sudo ninja -C build install
+    sudo ldconfig
+    cd ..
+    rm -rf fuse-${FUSE_VERSION} fuse-${FUSE_VERSION}.tar.gz
+fi
+
+echo "Dependency installation complete." 


### PR DESCRIPTION
## Summary
- add a helper script to install system dependencies (libsodium, libzstd, libfuse3, etc.)
- document the new script in README build instructions

## Testing
- `sudo ./setup_dependencies.sh`
- `cmake -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build`
- `ctest --output-on-failure -VV` *(fails: IntegrationTest.EndToEndFileCreation, FuseTestEnvSetup)*

------
https://chatgpt.com/codex/tasks/task_e_6840b5a220588328a114ee171ec1163e