### PR TITLE
Fix Node startup parameters in FUSE setup script

### DIFF
--- a/tests/setup_fuse_test_env.sh
+++ b/tests/setup_fuse_test_env.sh
@@ -37,7 +37,7 @@ do
     NODE_NAME="Node$i"
     NODE_PORT=$((NODE_START_PORT + i))
     echo "INFO: Starting $NODE_NAME on port $NODE_PORT..."
-    nohup ../node $NODE_NAME $NODE_PORT > /tmp/$NODE_NAME.log 2>&1 < /dev/null &
+    nohup ../node $NODE_NAME $NODE_PORT 127.0.0.1 50505 > /tmp/$NODE_NAME.log 2>&1 < /dev/null &
     NODE_PID=$!
     echo $NODE_PID > /tmp/$NODE_NAME.pid
     # Store PIDs in an array for later checks and cleanup


### PR DESCRIPTION
## Summary
- fix the `setup_fuse_test_env.sh` script so node processes receive the
  metaserver address and port during startup

## Testing
- `ctest --output-on-failure` *(fails: FuseTestEnvSetup)*

------
https://chatgpt.com/codex/tasks/task_e_6840b9f75e9883289dbccf25cd09eef5