### PR TITLE
Implement basic key management module

### DIFF
--- a/include/utilities/key_manager.hpp
+++ b/include/utilities/key_manager.hpp
@@ -1,0 +1,43 @@
+#ifndef KEY_MANAGER_HPP
+#define KEY_MANAGER_HPP
+
+#include <array>
+#include <mutex>
+#include <sodium.h>
+#include <string>
+
+namespace simplidfs {
+
+class KeyManager {
+public:
+    static KeyManager& getInstance();
+
+    // Initializes the key manager. Reads key from the environment or generates a new one.
+    void initialize();
+
+    // Copies the cluster-wide key into the provided array.
+    void getClusterKey(std::array<unsigned char, crypto_aead_aes256gcm_KEYBYTES>& out) const;
+
+    // Placeholders for future per-user and per-volume keys.
+    void getUserKey(const std::string& userId,
+                    std::array<unsigned char, crypto_aead_aes256gcm_KEYBYTES>& out) const;
+    void getVolumeKey(const std::string& volumeId,
+                      std::array<unsigned char, crypto_aead_aes256gcm_KEYBYTES>& out) const;
+
+private:
+    KeyManager();
+    ~KeyManager();
+    KeyManager(const KeyManager&) = delete;
+    KeyManager& operator=(const KeyManager&) = delete;
+
+    bool loadKeyFromEnv();
+    void generateClusterKey();
+
+    unsigned char* key_;
+    bool initialized_;
+    mutable std::mutex mutex_;
+};
+
+} // namespace simplidfs
+
+#endif // KEY_MANAGER_HPP

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(SimpliDFS_Utils
     message.cpp
     cid_utils.cpp  # Added cid_utils.cpp
     blockio.cpp    # Moved from BlockIOLib
+    key_manager.cpp
 )
 target_include_directories(SimpliDFS_Utils
     PUBLIC

--- a/src/utilities/key_manager.cpp
+++ b/src/utilities/key_manager.cpp
@@ -1,0 +1,92 @@
+#include "utilities/key_manager.hpp"
+#include <cstdlib>  // for getenv
+#include <cstring>
+#include <stdexcept>
+#include <sodium.h>
+
+namespace simplidfs {
+
+KeyManager& KeyManager::getInstance() {
+    static KeyManager instance;
+    return instance;
+}
+
+KeyManager::KeyManager() : key_(nullptr), initialized_(false) {}
+
+KeyManager::~KeyManager() {
+    if (key_) {
+        sodium_memzero(key_, crypto_aead_aes256gcm_KEYBYTES);
+        sodium_free(key_);
+        key_ = nullptr;
+    }
+}
+
+void KeyManager::initialize() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (initialized_) {
+        return;
+    }
+
+    if (sodium_init() < 0) {
+        throw std::runtime_error("Failed to initialize libsodium");
+    }
+
+    key_ = static_cast<unsigned char*>(sodium_malloc(crypto_aead_aes256gcm_KEYBYTES));
+    if (!key_) {
+        throw std::runtime_error("Unable to allocate secure memory for encryption key");
+    }
+
+    if (!loadKeyFromEnv()) {
+        generateClusterKey();
+    }
+
+    initialized_ = true;
+}
+
+bool KeyManager::loadKeyFromEnv() {
+    const char* env_key = std::getenv("SIMPLIDFS_CLUSTER_KEY");
+    if (!env_key) {
+        return false;
+    }
+    std::string hex(env_key);
+    if (hex.size() != crypto_aead_aes256gcm_KEYBYTES * 2) {
+        return false;
+    }
+    for (size_t i = 0; i < crypto_aead_aes256gcm_KEYBYTES; ++i) {
+        std::string byte_str = hex.substr(i * 2, 2);
+        try {
+            unsigned long byte_val = std::stoul(byte_str, nullptr, 16);
+            key_[i] = static_cast<unsigned char>(byte_val);
+        } catch (...) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void KeyManager::generateClusterKey() {
+    randombytes_buf(key_, crypto_aead_aes256gcm_KEYBYTES);
+}
+
+void KeyManager::getClusterKey(std::array<unsigned char, crypto_aead_aes256gcm_KEYBYTES>& out) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!initialized_) {
+        throw std::runtime_error("KeyManager not initialized");
+    }
+    std::memcpy(out.data(), key_, crypto_aead_aes256gcm_KEYBYTES);
+}
+
+void KeyManager::getUserKey(const std::string& /*userId*/,
+                            std::array<unsigned char, crypto_aead_aes256gcm_KEYBYTES>& out) const {
+    // Future implementation will provide per-user keys
+    getClusterKey(out);
+}
+
+void KeyManager::getVolumeKey(const std::string& /*volumeId*/,
+                              std::array<unsigned char, crypto_aead_aes256gcm_KEYBYTES>& out) const {
+    // Future implementation will provide per-volume keys
+    getClusterKey(out);
+}
+
+} // namespace simplidfs
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(SimpliDFSTests
     logger_tests.cpp      # Added new logger tests file
     blockio_test.cpp      # Added blockio tests
     cid_tests.cpp         # Added CID conversion tests
+    key_manager_tests.cpp
     integration_tests.cpp # Added new integration tests file
     # Removed direct compilation of utility sources:
     # ../../src/utilities/filesystem.cpp

--- a/tests/key_manager_tests.cpp
+++ b/tests/key_manager_tests.cpp
@@ -1,0 +1,14 @@
+#include "gtest/gtest.h"
+#include "utilities/key_manager.hpp"
+#include <array>
+#include <string>
+
+TEST(KeyManagerTest, ReturnsConsistentKey) {
+    simplidfs::KeyManager& km = simplidfs::KeyManager::getInstance();
+    km.initialize();
+    std::array<unsigned char, crypto_aead_aes256gcm_KEYBYTES> key1;
+    km.getClusterKey(key1);
+    std::array<unsigned char, crypto_aead_aes256gcm_KEYBYTES> key2;
+    km.getClusterKey(key2);
+    EXPECT_EQ(key1, key2);
+}


### PR DESCRIPTION
## Summary
- add `KeyManager` singleton for cluster-wide encryption key management
- integrate new module into utilities build
- add minimal test for key manager behavior

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `ctest --output-on-failure -VV` *(fails: FuseTestEnvSetup)*

------
https://chatgpt.com/codex/tasks/task_e_6840bcf1fea48328a9f81da1b6862c2a