### PR TITLE
Implement chunk store and merkle directory hashing

### DIFF
--- a/include/utilities/chunk_store.hpp
+++ b/include/utilities/chunk_store.hpp
@@ -1,0 +1,26 @@
+#ifndef CHUNK_STORE_HPP
+#define CHUNK_STORE_HPP
+
+#include <unordered_map>
+#include <vector>
+#include <string>
+#include <mutex>
+#include <cstddef>
+
+class ChunkStore {
+public:
+    // Adds a chunk and returns its content-addressed hash (CID)
+    std::string addChunk(const std::vector<std::byte>& data);
+
+    // Checks if a chunk exists
+    bool hasChunk(const std::string& cid) const;
+
+    // Retrieves a chunk by CID. Returns empty vector if not found
+    std::vector<std::byte> getChunk(const std::string& cid) const;
+
+private:
+    mutable std::mutex mutex_;
+    std::unordered_map<std::string, std::vector<std::byte>> chunks_;
+};
+
+#endif // CHUNK_STORE_HPP

--- a/include/utilities/merkle_tree.hpp
+++ b/include/utilities/merkle_tree.hpp
@@ -1,0 +1,16 @@
+#ifndef MERKLE_TREE_HPP
+#define MERKLE_TREE_HPP
+
+#include <string>
+#include <vector>
+#include <utility>
+#include "utilities/chunk_store.hpp"
+
+class MerkleTree {
+public:
+    // Compute a directory hash from child name/hash pairs.
+    // Entries should be provided as {name, cid}.
+    static std::string hashDirectory(const std::vector<std::pair<std::string, std::string>>& entries, ChunkStore& store);
+};
+
+#endif // MERKLE_TREE_HPP

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -12,6 +12,8 @@ add_library(SimpliDFS_Utils
     cid_utils.cpp  # Added cid_utils.cpp
     blockio.cpp    # Moved from BlockIOLib
     key_manager.cpp
+    chunk_store.cpp
+    merkle_tree.cpp
 )
 target_include_directories(SimpliDFS_Utils
     PUBLIC

--- a/src/utilities/chunk_store.cpp
+++ b/src/utilities/chunk_store.cpp
@@ -1,0 +1,27 @@
+#include "utilities/chunk_store.hpp"
+#include "utilities/blockio.hpp"
+
+std::string ChunkStore::addChunk(const std::vector<std::byte>& data) {
+    BlockIO bio;
+    if (!data.empty()) {
+        bio.ingest(data.data(), data.size());
+    }
+    DigestResult dr = bio.finalize_hashed();
+    std::lock_guard<std::mutex> lock(mutex_);
+    chunks_[dr.cid] = dr.raw;
+    return dr.cid;
+}
+
+bool ChunkStore::hasChunk(const std::string& cid) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return chunks_.count(cid) > 0;
+}
+
+std::vector<std::byte> ChunkStore::getChunk(const std::string& cid) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = chunks_.find(cid);
+    if (it != chunks_.end()) {
+        return it->second;
+    }
+    return {};
+}

--- a/src/utilities/merkle_tree.cpp
+++ b/src/utilities/merkle_tree.cpp
@@ -1,0 +1,21 @@
+#include "utilities/merkle_tree.hpp"
+#include "utilities/blockio.hpp"
+#include <algorithm>
+
+std::string MerkleTree::hashDirectory(const std::vector<std::pair<std::string, std::string>>& entries, ChunkStore& store) {
+    std::vector<std::pair<std::string, std::string>> sorted = entries;
+    std::sort(sorted.begin(), sorted.end(), [](const auto& a, const auto& b){ return a.first < b.first; });
+
+    BlockIO bio;
+    for (const auto& e : sorted) {
+        std::vector<std::byte> name_bytes;
+        for(char c : e.first) name_bytes.push_back(std::byte(c));
+        bio.ingest(name_bytes.data(), name_bytes.size());
+        std::vector<std::byte> hash_bytes;
+        for(char c : e.second) hash_bytes.push_back(std::byte(c));
+        bio.ingest(hash_bytes.data(), hash_bytes.size());
+    }
+    DigestResult dr = bio.finalize_hashed();
+    store.addChunk(dr.raw); // store directory representation itself
+    return dr.cid;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(SimpliDFSTests
     blockio_test.cpp      # Added blockio tests
     cid_tests.cpp         # Added CID conversion tests
     key_manager_tests.cpp
+    chunk_store_tests.cpp
     integration_tests.cpp # Added new integration tests file
     # Removed direct compilation of utility sources:
     # ../../src/utilities/filesystem.cpp

--- a/tests/chunk_store_tests.cpp
+++ b/tests/chunk_store_tests.cpp
@@ -1,0 +1,16 @@
+#include "gtest/gtest.h"
+#include "utilities/chunk_store.hpp"
+#include <string>
+
+TEST(ChunkStoreTest, AddAndRetrieveChunk) {
+    ChunkStore store;
+    std::string data = "hello";
+    std::vector<std::byte> bytes;
+    for(char c : data) bytes.push_back(std::byte(c));
+    std::string cid = store.addChunk(bytes);
+    EXPECT_FALSE(cid.empty());
+    EXPECT_TRUE(store.hasChunk(cid));
+    std::vector<std::byte> out = store.getChunk(cid);
+    std::string out_str(reinterpret_cast<const char*>(out.data()), out.size());
+    EXPECT_EQ(out_str, data);
+}

--- a/tests/metaserver_tests.cpp
+++ b/tests/metaserver_tests.cpp
@@ -1,6 +1,7 @@
 // Unit Tests for MetadataManager
 #include "gtest/gtest.h"
 #include "metaserver/metaserver.h"
+#include "utilities/blockio.hpp"
 
 // Test Fixture for MetadataManager
 class MetadataManagerTest : public ::testing::Test {
@@ -122,6 +123,13 @@ TEST_F(MetadataManagerTest, SaveLoadMetadataWithModesAndSizes) {
     EXPECT_EQ(loaded_size, static_cast<uint64_t>(11));
     std::vector<std::string> loaded_nodes = mm2.getFileNodes(filename);
     EXPECT_EQ(loaded_nodes, nodes);
+
+    BlockIO bio;
+    std::vector<std::byte> bytes;
+    for(char c : std::string("hello world")) bytes.push_back(std::byte(c));
+    bio.ingest(bytes.data(), bytes.size());
+    DigestResult dr = bio.finalize_hashed();
+    EXPECT_EQ(mm2.getFileHash(filename), dr.cid);
 
     std::remove(fm_path.c_str());
     std::remove(nr_path.c_str());


### PR DESCRIPTION
## Summary
- add `ChunkStore` for content-addressed storage
- implement simple `MerkleTree::hashDirectory`
- track `fileHashes` in `MetadataManager`
- save/load hashes with metadata
- test chunk store and metadata hash persistence

## Testing
- `./setup_dependencies.sh`
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure` (fails: FuseTestEnvSetup)

------
https://chatgpt.com/codex/tasks/task_e_6840c52441288328b26361ac3e99c5f1