### PR TITLE
Implement snapshot CAR export

### DIFF
--- a/include/utilities/chunk_store.hpp
+++ b/include/utilities/chunk_store.hpp
@@ -32,6 +32,9 @@ public:
     GCStats garbageCollect(const std::unordered_set<std::string>& referencedCids,
                            bool dryRun);
 
+    // Retrieve copy of all stored chunks
+    std::unordered_map<std::string, std::vector<std::byte>> getAllChunks() const;
+
 private:
     mutable std::mutex mutex_;
     std::unordered_map<std::string, std::vector<std::byte>> chunks_;

--- a/include/utilities/cid_utils.hpp
+++ b/include/utilities/cid_utils.hpp
@@ -16,6 +16,8 @@
 
 namespace sgns::utils {
 
+extern const std::vector<uint8_t> CID_PREFIX;
+
 /**
  * @brief Converts a SHA-256 digest to a CIDv1 string.
  * @param digest The SHA-256 digest.
@@ -30,6 +32,11 @@ std::string digest_to_cid(const std::array<uint8_t, crypto_hash_sha256_BYTES>& d
  * @throws std::runtime_error if the CID is invalid.
  */
 std::array<uint8_t, crypto_hash_sha256_BYTES> cid_to_digest(const std::string& cid);
+
+/**
+ * @brief Convert a CIDv1 string to its raw byte representation.
+ */
+std::vector<uint8_t> cid_to_bytes(const std::string& cid);
 
 } // namespace sgns::utils
 

--- a/include/utilities/filesystem.h
+++ b/include/utilities/filesystem.h
@@ -114,6 +114,14 @@ public:
     // Return set of all CIDs referenced by files and snapshots
     std::unordered_set<std::string> getAllCids() const;
 
+    /**
+     * @brief Export a snapshot as an IPLD CAR file.
+     * @param name The snapshot name to export.
+     * @param carPath Destination path for the CAR file.
+     * @return True on success, false if the snapshot does not exist or on I/O error.
+     */
+    bool snapshotExportCar(const std::string& name, const std::string& carPath) const;
+
 private:
     /**
      * @brief In-memory storage for files, mapping filename to its content (now binary).

--- a/src/utilities/chunk_store.cpp
+++ b/src/utilities/chunk_store.cpp
@@ -46,3 +46,8 @@ ChunkStore::GCStats ChunkStore::garbageCollect(const std::unordered_set<std::str
     }
     return stats;
 }
+
+std::unordered_map<std::string, std::vector<std::byte>> ChunkStore::getAllChunks() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return chunks_;
+}

--- a/src/utilities/cid_utils.cpp
+++ b/src/utilities/cid_utils.cpp
@@ -59,4 +59,12 @@ std::array<uint8_t, crypto_hash_sha256_BYTES> cid_to_digest(const std::string& c
     return digest;
 }
 
+std::vector<uint8_t> cid_to_bytes(const std::string& cid) {
+    auto digest = cid_to_digest(cid);
+    std::vector<uint8_t> bytes;
+    bytes.insert(bytes.end(), CID_PREFIX.begin(), CID_PREFIX.end());
+    bytes.insert(bytes.end(), digest.begin(), digest.end());
+    return bytes;
+}
+
 } // namespace sgns::utils


### PR DESCRIPTION
## Summary
- enable exporting snapshots to IPLD CAR format
- expose chunk store contents
- extend CID utilities
- add a unit test to ensure CAR files are produced

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `ctest --output-on-failure -VV` *(fails: FuseTestEnvSetup)*

------
https://chatgpt.com/codex/tasks/task_e_6840d1babbac83288059d42f1771faa3