### PR TITLE
Add replication and corruption healing

### DIFF
--- a/PROGRESS.MD
+++ b/PROGRESS.MD
@@ -1,4 +1,4 @@
-# SimpliDFS Project - Current Progress and TODO List
+#SimpliDFS Project - Current Progress and TODO List
 
 ## Current Progress
 
@@ -46,6 +46,8 @@
 ### 3. Fault Tolerance
 - **Replication**: Implement replication of file chunks (Currently, whole file replication logic is in place during creation; re-replication data transfer is stubbed).
 - **Failure Handling**: Define behavior and implement data transfer when a node goes offline (Currently, node failure detection and selection of new nodes for replicas is implemented; data transfer is stubbed).
+- **Background Verification**: Nodes now periodically verify local file hashes and automatically heal corrupted copies by fetching clean data from peers.
+- **Replication Factor**: System defaults to a replication factor of 3 for all blocks.
 
 ### 4. Metadata Persistence
 - **Metadata Persistence**: Complete.
@@ -68,4 +70,3 @@
 - Implement the actual data transfer mechanisms for file replication and re-replication.
 - Develop comprehensive unit tests for all implemented features.
 - Begin work on file encryption.
-

--- a/README.MD
+++ b/README.MD
@@ -1,4 +1,4 @@
-# SimpliDFS
+#SimpliDFS
 
 SimpliDFS is a distributed file system project designed to manage files across multiple nodes. The system includes components for metadata management, file operations, message handling, and will soon include network communication between nodes for efficient file distribution and fault tolerance.
 
@@ -29,6 +29,8 @@ SimpliDFS is a distributed file system project designed to manage files across m
 - Implements a replication strategy during file creation to distribute multiple copies of files across available live nodes.
 - Includes logic to detect node failures (via heartbeats) and identify files needing re-replication.
 - Note: Actual network communication for data transfer (including initial replication and re-replication) now utilizes the integrated networking library.
+- Default replication factor is **3** and block writes are replicated to all replicas.
+- Each storage node runs a background verifier thread that checks file hashes and heals corrupted replicas by fetching a clean copy from peers.
 
 ## Current Progress
 Significant progress has been made on core distributed file system logic:
@@ -127,3 +129,8 @@ Feel free to contribute to the project by opening issues, submitting pull reques
 
 ## License
 This project is licensed under the MIT License.
+
+## Chaos Testing
+The `tests/chaos_kill_node.sh` script simulates node failures by randomly killing
+one storage node every five minutes for two hours. Use this after launching the
+metaserver and nodes to evaluate replication healing.

--- a/include/node/node.h
+++ b/include/node/node.h
@@ -1,29 +1,33 @@
 /**
  * @file node.h
  * @brief Defines the Node class for the SimpliDFS distributed file system.
- * 
- * The Node class represents a storage node in the system. It is responsible for:
+ *
+ * The Node class represents a storage node in the system. It is responsible
+ * for:
  * - Listening for incoming requests from clients or other nodes.
- * - Handling file operations (read, write, delete) by interacting with its local FileSystem.
+ * - Handling file operations (read, write, delete) by interacting with its
+ * local FileSystem.
  * - Registering with the MetadataManager.
  * - Periodically sending heartbeats to the MetadataManager.
- * - Interacting with the NetworkingLibrary (currently stubbed/conceptual) for communication.
+ * - Interacting with the NetworkingLibrary (currently stubbed/conceptual) for
+ * communication.
  */
 
-#include <iostream>
-#include <string>
-#include <vector> // Required for std::vector
+#include "utilities/client.h"
 #include "utilities/filesystem.h"
 #include "utilities/message.h"
-#include "utilities/server.h"
-#include "utilities/client.h"
 #include "utilities/networkexception.h"
-#include <thread>
+#include "utilities/server.h"
 #include <chrono> // Required for std::chrono
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector> // Required for std::vector
 
 /**
  * @brief Represents a storage node in the SimpliDFS system.
- * 
+ *
  * Each Node instance runs a server to listen for requests, manages a local
  * FileSystem instance for storing file data, and communicates with the
  * MetadataManager for registration and heartbeats. It also handles commands
@@ -31,266 +35,432 @@
  */
 class Node {
 private:
-    std::string nodeName;       ///< Unique identifier for this node.
-    Networking::Server server;  ///< Server instance from NetworkingLibrary to listen for incoming connections.
-    FileSystem fileSystem;      ///< Local file system manager for this node.
+  std::string nodeName;      ///< Unique identifier for this node.
+  Networking::Server server; ///< Server instance from NetworkingLibrary to
+                             ///< listen for incoming connections.
+  FileSystem fileSystem;     ///< Local file system manager for this node.
+  void verifyLoop(const std::string &metaAddr, int metaPort,
+                  int intervalSeconds) {
+    while (true) {
+      for (const auto &f : fileSystem.listFiles()) {
+        if (!fileSystem.verifyFileIntegrity(f)) {
+          std::cout << "[NODE " << nodeName << "] Detected corruption in " << f
+                    << std::endl;
+
+          Message req;
+          req._Type = MessageType::GetFileNodeLocationsRequest;
+          req._Path = f;
+          try {
+            Networking::Client mc(metaAddr.c_str(), metaPort);
+            mc.Send(Message::Serialize(req).c_str());
+            std::vector<char> respVec = mc.Receive();
+            mc.Disconnect();
+            if (!respVec.empty()) {
+              Message resp = Message::Deserialize(
+                  std::string(respVec.begin(), respVec.end()));
+              std::stringstream ss(resp._Data);
+              std::string addr;
+              while (std::getline(ss, addr, ',')) {
+                if (addr.empty())
+                  continue;
+                if (addr == "127.0.0.1:" + std::to_string(server.GetPort()))
+                  continue;
+                std::string ip = addr.substr(0, addr.find(':'));
+                int port = std::stoi(addr.substr(addr.find(':') + 1));
+                try {
+                  Networking::Client sc(ip.c_str(), port);
+                  Message rm;
+                  rm._Type = MessageType::ReadFile;
+                  rm._Filename = f;
+                  sc.Send(Message::Serialize(rm).c_str());
+                  std::vector<char> fileVec = sc.Receive();
+                  sc.Disconnect();
+                  if (!fileVec.empty()) {
+                    std::string data(fileVec.begin(), fileVec.end());
+                    fileSystem.writeFile(f, data);
+                    std::cout << "[NODE " << nodeName << "] Healed " << f
+                              << " from " << addr << std::endl;
+                    break;
+                  }
+                } catch (...) {
+                }
+              }
+            }
+          } catch (...) {
+            std::cerr << "[NODE " << nodeName
+                      << "] Error contacting metaserver for healing"
+                      << std::endl;
+          }
+        }
+      }
+      std::this_thread::sleep_for(std::chrono::seconds(intervalSeconds));
+    }
+  }
 
 public:
-    /**
-     * @brief Checks if a file exists on the node's local filesystem.
-     * @param filename The name of the file to check.
-     * @return True if the file exists, false otherwise.
-     */
-    bool checkFileExistsOnNode(const std::string& filename) const; // Made const again
+  /**
+   * @brief Checks if a file exists on the node's local filesystem.
+   * @param filename The name of the file to check.
+   * @return True if the file exists, false otherwise.
+   */
+  bool
+  checkFileExistsOnNode(const std::string &filename) const; // Made const again
 
-    /**
-     * @brief Constructs a Node object.
-     * @param name The unique name (identifier) for this node.
-     * @param port The port number on which this node's server should listen.
-     */
-    Node(const std::string& name, int port) : nodeName(name), server(port) {}
+  /**
+   * @brief Constructs a Node object.
+   * @param name The unique name (identifier) for this node.
+   * @param port The port number on which this node's server should listen.
+   */
+  Node(const std::string &name, int port) : nodeName(name), server(port) {}
 
-    /**
-     * @brief Starts the node's operations.
-     * This includes starting the server to listen for requests and initiating
-     * the periodic heartbeat sender.
-     */
-    void start() {
-        std::cout << "Node " << nodeName << ": Attempting to start server on port " << server.GetPort() << std::endl;
-        if (!this->server.startListening()) {
-            std::cerr << "Node " << nodeName << ": CRITICAL - Failed to start server listening on port " << server.GetPort() << "." << std::endl;
-            // Depending on desired behavior, could throw an exception or set an error state.
-            // For now, just log and don't start other threads.
-            return;
+  /**
+   * @brief Starts the node's operations.
+   * This includes starting the server to listen for requests and initiating
+   * the periodic heartbeat sender.
+   */
+  void start() {
+    std::cout << "Node " << nodeName << ": Attempting to start server on port "
+              << server.GetPort() << std::endl;
+    if (!this->server.startListening()) {
+      std::cerr << "Node " << nodeName
+                << ": CRITICAL - Failed to start server listening on port "
+                << server.GetPort() << "." << std::endl;
+      // Depending on desired behavior, could throw an exception or set an error
+      // state. For now, just log and don't start other threads.
+      return;
+    }
+    std::cout << "Node " << nodeName << ": Server started successfully on port "
+              << server.GetPort() << std::endl;
+
+    // Start the node's server in a separate thread to listen to requests
+    std::thread serverThread(&Node::listenForRequests, this);
+    serverThread.detach();
+    std::cout << "Node " << nodeName << ": Listener thread detached."
+              << std::endl;
+
+    // Start the heartbeat thread
+    // Replace "127.0.0.1" and 50505 with actual MetadataManager IP and port if
+    // different Heartbeat interval is 10 seconds
+    std::thread heartbeatThread(&Node::sendHeartbeatPeriodically, this,
+                                "127.0.0.1", 50505, 10);
+    heartbeatThread.detach();
+    std::cout << "Node " << nodeName << ": Heartbeat thread detached."
+              << std::endl;
+
+    std::thread verifyThread(&Node::verifyLoop, this, "127.0.0.1", 50505, 60);
+    verifyThread.detach();
+    std::cout << "Node " << nodeName << ": Verifier thread detached."
+              << std::endl;
+
+    // Original log: std::cout << "Node " << nodeName << " started on port " <<
+    // server.GetPort() << std::endl; This is now logged above after successful
+    // startListening()
+  }
+
+  /**
+   * @brief Registers this node with the MetadataManager.
+   * Sends a RegisterNode message containing this node's name, address
+   * (placeholder), and listening port.
+   * @param metadataManagerAddress The IP address or hostname of the
+   * MetadataManager.
+   * @param metadataManagerPort The port number of the MetadataManager.
+   */
+  void registerWithMetadataManager(const std::string &metadataManagerAddress,
+                                   int metadataManagerPort) {
+    Message msg;
+    msg._Type = MessageType::RegisterNode;
+    msg._Filename =
+        this->nodeName; // Using _Filename to carry the node identifier
+    msg._NodeAddress = "127.0.0.1"; // Placeholder for node's actual address
+    msg._NodePort = this->server.GetPort(); // Node's listening port
+
+    // This function would make a network call to the MetadataManager
+    sendMessageToMetadataManager(metadataManagerAddress, metadataManagerPort,
+                                 msg);
+    std::cout << "Node " << nodeName
+              << " attempting to register with MetadataManager at "
+              << metadataManagerAddress << ":" << metadataManagerPort
+              << std::endl;
+  }
+
+  /**
+   * @brief Listens for incoming client connections and spawns threads to handle
+   * them. This method runs in a loop as long as the server is running.
+   */
+  void listenForRequests() {
+    while (server.ServerIsRunning()) {
+      Networking::ClientConnection client = server.Accept();
+      std::thread clientThread(&Node::handleClient, this, client);
+      clientThread.detach();
+    }
+  }
+
+  /**
+   * @brief Handles an individual client connection.
+   * Receives a message, deserializes it, and processes it based on its type.
+   * Supported message types include WriteFile, ReadFile, DeleteFile,
+   * ReplicateFileCommand, and ReceiveFileCommand.
+   * @param client The ClientConnection object representing the connected
+   * client.
+   * @note This method uses the local FileSystem to perform file operations.
+   *       Error handling for message deserialization and network operations is
+   * included.
+   */
+  void handleClient(Networking::ClientConnection client) {
+    try {
+      std::vector<char> request_vector = server.Receive(client);
+      if (request_vector.empty()) {
+        std::cerr << "Node " << nodeName << " received empty data."
+                  << std::endl;
+        return;
+      }
+      std::string request_str(request_vector.begin(), request_vector.end());
+      Message message = Message::Deserialize(request_str);
+
+      switch (message._Type) {
+      case MessageType::WriteFile: {
+        bool success = false;
+        if (message._Content
+                .empty()) { // Treat empty content write as create file
+          success = fileSystem.createFile(message._Filename);
+          if (success) {
+            server.Send(("File " + message._Filename + " created successfully.")
+                            .c_str(),
+                        client);
+          } else {
+            // createFile logs if it already exists or other errors.
+            // Check if it already exists to send a different success message
+            // for idempotency.
+            if (fileSystem.readFile(message._Filename).empty() &&
+                !fileSystem.getXattr(message._Filename, "user.cid").empty()) {
+              // This is tricky: readFile returns "" for non-existent or for
+              // truly empty (but existing) files. If it has xattrs, it must
+              // exist. A file created by createFile will have empty content and
+              // no xattrs. A proper fileSystem.fileExists() would be better.
+              // For now, if createFile fails, assume it might be due to already
+              // existing. Let's refine: if createFile returns false, it means
+              // it already existed (as per its log). This can be treated as
+              // success for "ensure exists".
+              Logger::getInstance().log(
+                  LogLevel::INFO,
+                  "Node " + nodeName +
+                      ": WriteFile with empty content for existing file " +
+                      message._Filename + " (treated as success).");
+              server.Send(("File " + message._Filename +
+                           " (already exists) processed successfully.")
+                              .c_str(),
+                          client);
+              success = true; // Idempotent success
+            } else {
+              server.Send(("Error: Unable to create file " + message._Filename +
+                           " (may already exist or other issue).")
+                              .c_str(),
+                          client);
+            }
+          }
+        } else { // Non-empty content, try to write (will fail if file doesn't
+                 // exist)
+          success = fileSystem.writeFile(message._Filename, message._Content);
+          if (success) {
+            server.Send(("File " + message._Filename + " written successfully.")
+                            .c_str(),
+                        client);
+          } else {
+            server.Send(
+                ("Error: Unable to write file " + message._Filename + ".")
+                    .c_str(),
+                client);
+          }
         }
-        std::cout << "Node " << nodeName << ": Server started successfully on port " << server.GetPort() << std::endl;
-
-        // Start the node's server in a separate thread to listen to requests
-        std::thread serverThread(&Node::listenForRequests, this);
-        serverThread.detach();
-        std::cout << "Node " << nodeName << ": Listener thread detached." << std::endl;
-
-        // Start the heartbeat thread
-        // Replace "127.0.0.1" and 50505 with actual MetadataManager IP and port if different
-        // Heartbeat interval is 10 seconds
-        std::thread heartbeatThread(&Node::sendHeartbeatPeriodically, this, "127.0.0.1", 50505, 10);
-        heartbeatThread.detach();
-        std::cout << "Node " << nodeName << ": Heartbeat thread detached." << std::endl;
-
-        // Original log: std::cout << "Node " << nodeName << " started on port " << server.GetPort() << std::endl;
-        // This is now logged above after successful startListening()
-    }
-
-    /**
-     * @brief Registers this node with the MetadataManager.
-     * Sends a RegisterNode message containing this node's name, address (placeholder), 
-     * and listening port.
-     * @param metadataManagerAddress The IP address or hostname of the MetadataManager.
-     * @param metadataManagerPort The port number of the MetadataManager.
-     */
-    void registerWithMetadataManager(const std::string& metadataManagerAddress, int metadataManagerPort) {
-        Message msg;
-        msg._Type = MessageType::RegisterNode;
-        msg._Filename = this->nodeName; // Using _Filename to carry the node identifier
-        msg._NodeAddress = "127.0.0.1"; // Placeholder for node's actual address
-        msg._NodePort = this->server.GetPort(); // Node's listening port
-
-        // This function would make a network call to the MetadataManager
-        sendMessageToMetadataManager(metadataManagerAddress, metadataManagerPort, msg);
-        std::cout << "Node " << nodeName << " attempting to register with MetadataManager at "
-                  << metadataManagerAddress << ":" << metadataManagerPort << std::endl;
-    }
-
-    /**
-     * @brief Listens for incoming client connections and spawns threads to handle them.
-     * This method runs in a loop as long as the server is running.
-     */
-    void listenForRequests() {
-        while (server.ServerIsRunning()) {
-            Networking::ClientConnection client = server.Accept();
-            std::thread clientThread(&Node::handleClient, this, client);
-            clientThread.detach();
+        break;
+      }
+      case MessageType::ReadFile: {
+        std::string content = fileSystem.readFile(message._Filename);
+        if (!content.empty()) {
+          server.Send(content.c_str(), client);
+        } else {
+          server.Send("Error: File not found.", client);
         }
-    }
-
-    /**
-     * @brief Handles an individual client connection.
-     * Receives a message, deserializes it, and processes it based on its type.
-     * Supported message types include WriteFile, ReadFile, DeleteFile, 
-     * ReplicateFileCommand, and ReceiveFileCommand.
-     * @param client The ClientConnection object representing the connected client.
-     * @note This method uses the local FileSystem to perform file operations.
-     *       Error handling for message deserialization and network operations is included.
-     */
-    void handleClient(Networking::ClientConnection client) {
+        break;
+      }
+      // Note: The case for MessageType::RemoveFile has been removed.
+      // It was using fileSystem.writeFile with empty content, which is not a
+      // true delete. MessageType::DeleteFile is handled below and uses
+      // fileSystem.deleteFile. If MessageType::RemoveFile is a distinct, valid
+      // message type that should exist, it needs to be re-added to the
+      // MessageType enum in message.h. For now, assuming it was superseded by
+      // DeleteFile.
+      case MessageType::ReplicateFileCommand: {
+        std::string filenameToReplicate = message._Filename;
+        std::string targetNodeAddress = message._NodeAddress;
+        std::string sourceNodeForConfirmation =
+            message
+                ._Content; // Original source node ID for logging/confirmation
+        std::cout << "[NODE " << nodeName << "] Replicating "
+                  << filenameToReplicate << " to " << targetNodeAddress
+                  << std::endl;
+        std::string data = fileSystem.readFile(filenameToReplicate);
+        if (!data.empty()) {
+          std::string ip =
+              targetNodeAddress.substr(0, targetNodeAddress.find(':'));
+          int port = std::stoi(
+              targetNodeAddress.substr(targetNodeAddress.find(':') + 1));
+          try {
+            Networking::Client c(ip.c_str(), port);
+            Message w;
+            w._Type = MessageType::WriteFile;
+            w._Filename = filenameToReplicate;
+            w._Content = data;
+            c.Send(Message::Serialize(w).c_str());
+            (void)c.Receive();
+            c.Disconnect();
+          } catch (...) {
+            std::cerr << "[NODE " << nodeName << "] Replication to "
+                      << targetNodeAddress << " failed" << std::endl;
+          }
+        }
+        server.Send("Replication command processed.", client);
+        break;
+      }
+      case MessageType::ReceiveFileCommand: {
+        std::string filenameToReceive = message._Filename;
+        std::string sourceNodeAddress = message._NodeAddress;
+        std::string targetNodeForConfirmation =
+            message
+                ._Content; // Original target node ID for logging/confirmation
+        std::cout << "[NODE " << nodeName << "] Receiving " << filenameToReceive
+                  << " from " << sourceNodeAddress << std::endl;
+        std::string ip =
+            sourceNodeAddress.substr(0, sourceNodeAddress.find(':'));
+        int port = std::stoi(
+            sourceNodeAddress.substr(sourceNodeAddress.find(':') + 1));
         try {
-            std::vector<char> request_vector = server.Receive(client);
-            if (request_vector.empty()) {
-                std::cerr << "Node " << nodeName << " received empty data." << std::endl;
-                return;
-            }
-            std::string request_str(request_vector.begin(), request_vector.end());
-            Message message = Message::Deserialize(request_str);
-
-            switch (message._Type) {
-                case MessageType::WriteFile: {
-                    bool success = false;
-                    if (message._Content.empty()) { // Treat empty content write as create file
-                        success = fileSystem.createFile(message._Filename);
-                         if (success) {
-                            server.Send(("File " + message._Filename + " created successfully.").c_str(), client);
-                        } else {
-                            // createFile logs if it already exists or other errors.
-                            // Check if it already exists to send a different success message for idempotency.
-                            if (fileSystem.readFile(message._Filename).empty() && !fileSystem.getXattr(message._Filename, "user.cid").empty()) {
-                                // This is tricky: readFile returns "" for non-existent or for truly empty (but existing) files.
-                                // If it has xattrs, it must exist. A file created by createFile will have empty content and no xattrs.
-                                // A proper fileSystem.fileExists() would be better.
-                                // For now, if createFile fails, assume it might be due to already existing.
-                                // Let's refine: if createFile returns false, it means it already existed (as per its log).
-                                // This can be treated as success for "ensure exists".
-                                Logger::getInstance().log(LogLevel::INFO, "Node " + nodeName + ": WriteFile with empty content for existing file " + message._Filename + " (treated as success).");
-                                server.Send(("File " + message._Filename + " (already exists) processed successfully.").c_str(), client);
-                                success = true; // Idempotent success
-                            } else {
-                                server.Send(("Error: Unable to create file " + message._Filename + " (may already exist or other issue).").c_str(), client);
-                            }
-                        }
-                    } else { // Non-empty content, try to write (will fail if file doesn't exist)
-                        success = fileSystem.writeFile(message._Filename, message._Content);
-                        if (success) {
-                            server.Send(("File " + message._Filename + " written successfully.").c_str(), client);
-                        } else {
-                            server.Send(("Error: Unable to write file " + message._Filename + ".").c_str(), client);
-                        }
-                    }
-                    break;
-                }
-                case MessageType::ReadFile: {
-                    std::string content = fileSystem.readFile(message._Filename);
-                    if (!content.empty()) {
-                        server.Send(content.c_str(), client);
-                    } else {
-                        server.Send("Error: File not found.", client);
-                    }
-                    break;
-                }
-                // Note: The case for MessageType::RemoveFile has been removed. 
-                // It was using fileSystem.writeFile with empty content, which is not a true delete.
-                // MessageType::DeleteFile is handled below and uses fileSystem.deleteFile.
-                // If MessageType::RemoveFile is a distinct, valid message type that should exist,
-                // it needs to be re-added to the MessageType enum in message.h.
-                // For now, assuming it was superseded by DeleteFile.
-                case MessageType::ReplicateFileCommand: {
-                    std::string filenameToReplicate = message._Filename;
-                    std::string targetNodeAddress = message._NodeAddress;
-                    std::string sourceNodeForConfirmation = message._Content; // Original source node ID for logging/confirmation
-                    std::cout << "[NODE " << nodeName << "] Received ReplicateFileCommand for " << filenameToReplicate 
-                              << " to " << targetNodeAddress 
-                              << " (Original source: " << sourceNodeForConfirmation << ")" << std::endl;
-                    std::cout << "[NODE " << nodeName << "_STUB] Reading file " << filenameToReplicate 
-                              << " and simulating send to " << targetNodeAddress << std::endl;
-                    // STUB: actual_content = fileSystem.readFile(filenameToReplicate);
-                    // STUB: This node would then connect to targetNodeAddress and send the file
-                    // Example: Networking::Client clientToTarget(targetNodeAddress_ip, targetNodeAddress_port);
-                    // clientToTarget.Send(actual_content);
-                    server.Send("Replication command received.", client); // Acknowledge receipt
-                    break;
-                }
-                case MessageType::ReceiveFileCommand: {
-                    std::string filenameToReceive = message._Filename;
-                    std::string sourceNodeAddress = message._NodeAddress;
-                    std::string targetNodeForConfirmation = message._Content; // Original target node ID for logging/confirmation
-                    std::cout << "[NODE " << nodeName << "] Received ReceiveFileCommand for " << filenameToReceive 
-                              << " from " << sourceNodeAddress 
-                              << " (Original target: " << targetNodeForConfirmation << ")" << std::endl;
-                    std::cout << "[NODE " << nodeName << "_STUB] Simulating receive of " << filenameToReceive 
-                              << " from " << sourceNodeAddress << " and writing to local filesystem." << std::endl;
-                    // STUB: This node would expect a connection from sourceNodeAddress or initiate if needed
-                    // Example: std::string received_content = server.Receive(client_from_source_node);
-                    // fileSystem.writeFile(filenameToReceive, received_content);
-                    server.Send("Receive command acknowledged.", client); // Acknowledge receipt
-                    break;
-                }
-                case MessageType::DeleteFile: {
-                    std::cout << "[NODE " << nodeName << "] Received DeleteFile for " << message._Filename << std::endl;
-                    bool success = fileSystem.deleteFile(message._Filename);
-                    if (success) {
-                        std::cout << "[NODE " << nodeName << "] File " << message._Filename << " deleted successfully." << std::endl;
-                        // STUB: server.Send(("File " + message._Filename + " deleted.").c_str(), client);
-                        std::cout << "[NODE " << nodeName << "_STUB] Sent delete confirmation to metaserver/client." << std::endl;
-                    } else {
-                        std::cout << "[NODE " << nodeName << "] Error: Unable to delete file " << message._Filename << " (not found or other error)." << std::endl;
-                        // STUB: server.Send(("Error deleting " + message._Filename).c_str(), client);
-                         std::cout << "[NODE " << nodeName << "_STUB] Sent delete error to metaserver/client." << std::endl;
-                    }
-                    break;
-                }
-                default: {
-                    server.Send("Unknown request type.", client);
-                    break;
-                }
-            }
-        } catch (const std::runtime_error& e) { // Catching more specific runtime_error from Deserialize
-            std::cerr << "Error deserializing message or runtime issue in handleClient: " << e.what() << std::endl;
-            // Optionally, send an error response to the client if appropriate
-            // server.Send("Error: Malformed message received.", client);
-        } catch (const std::exception& e) { // Catching other general exceptions
-            std::cerr << "Error handling client: " << e.what() << std::endl;
+          Networking::Client sc(ip.c_str(), port);
+          Message r;
+          r._Type = MessageType::ReadFile;
+          r._Filename = filenameToReceive;
+          sc.Send(Message::Serialize(r).c_str());
+          std::vector<char> vec = sc.Receive();
+          sc.Disconnect();
+          if (!vec.empty()) {
+            std::string d(vec.begin(), vec.end());
+            fileSystem.writeFile(filenameToReceive, d);
+          }
+        } catch (...) {
+          std::cerr << "[NODE " << nodeName << "] Failed to receive file from "
+                    << sourceNodeAddress << std::endl;
         }
-    }
-
-    /**
-     * @brief Sends a message to the MetadataManager.
-     * Serializes the given Message object and sends it using the Networking::Client.
-     * @param metadataManagerAddress The IP address or hostname of the MetadataManager.
-     * @param metadataManagerPort The port number of the MetadataManager.
-     * @param message The Message object to send.
-     * @note This method currently uses STUBs for actual network sending via NetworkingLibrary.
-     */
-    void sendMessageToMetadataManager(const std::string& metadataManagerAddress, int metadataManagerPort, const Message& message) {
-        try {
-            Networking::Client client(metadataManagerAddress.c_str(), metadataManagerPort);
-            std::string serializedMessage = Message::Serialize(message);
-            client.Send(serializedMessage.c_str());
-            std::vector<char> response_vector = client.Receive();
-            if (response_vector.empty()) {
-                std::cout << "Node " << nodeName << " received empty response from MetadataManager." << std::endl;
-                // Handle empty response, maybe log or retry
-            }
-            // Only construct string if not empty, or handle empty string case
-            std::string response = "";
-            if (!response_vector.empty()){
-                response = std::string(response_vector.begin(), response_vector.end());
-            }
-            // Suppress noisy cout during tests, consider logging framework if complex logs needed
-            // std::cout << "Response from MetadataManager: " << response << std::endl;
-        } catch (const Networking::NetworkException& ne) {
-             std::cerr << "Network error sending message to MetadataManager: " << ne.what() << std::endl;
-        } catch (const std::exception& e) { // Catching other potential exceptions
-            std::cerr << "Error sending message to MetadataManager: " << e.what() << std::endl;
+        server.Send("Receive command processed.", client);
+        break;
+      }
+      case MessageType::DeleteFile: {
+        std::cout << "[NODE " << nodeName << "] Received DeleteFile for "
+                  << message._Filename << std::endl;
+        bool success = fileSystem.deleteFile(message._Filename);
+        if (success) {
+          std::cout << "[NODE " << nodeName << "] File " << message._Filename
+                    << " deleted successfully." << std::endl;
+          // STUB: server.Send(("File " + message._Filename + "
+          // deleted.").c_str(), client);
+          std::cout << "[NODE " << nodeName
+                    << "_STUB] Sent delete confirmation to metaserver/client."
+                    << std::endl;
+        } else {
+          std::cout << "[NODE " << nodeName << "] Error: Unable to delete file "
+                    << message._Filename << " (not found or other error)."
+                    << std::endl;
+          // STUB: server.Send(("Error deleting " + message._Filename).c_str(),
+          // client);
+          std::cout << "[NODE " << nodeName
+                    << "_STUB] Sent delete error to metaserver/client."
+                    << std::endl;
         }
+        break;
+      }
+      default: {
+        server.Send("Unknown request type.", client);
+        break;
+      }
+      }
+    } catch (const std::runtime_error
+                 &e) { // Catching more specific runtime_error from Deserialize
+      std::cerr
+          << "Error deserializing message or runtime issue in handleClient: "
+          << e.what() << std::endl;
+      // Optionally, send an error response to the client if appropriate
+      // server.Send("Error: Malformed message received.", client);
+    } catch (const std::exception &e) { // Catching other general exceptions
+      std::cerr << "Error handling client: " << e.what() << std::endl;
     }
+  }
+
+  /**
+   * @brief Sends a message to the MetadataManager.
+   * Serializes the given Message object and sends it using the
+   * Networking::Client.
+   * @param metadataManagerAddress The IP address or hostname of the
+   * MetadataManager.
+   * @param metadataManagerPort The port number of the MetadataManager.
+   * @param message The Message object to send.
+   * @note This method currently uses STUBs for actual network sending via
+   * NetworkingLibrary.
+   */
+  void sendMessageToMetadataManager(const std::string &metadataManagerAddress,
+                                    int metadataManagerPort,
+                                    const Message &message) {
+    try {
+      Networking::Client client(metadataManagerAddress.c_str(),
+                                metadataManagerPort);
+      std::string serializedMessage = Message::Serialize(message);
+      client.Send(serializedMessage.c_str());
+      std::vector<char> response_vector = client.Receive();
+      if (response_vector.empty()) {
+        std::cout << "Node " << nodeName
+                  << " received empty response from MetadataManager."
+                  << std::endl;
+        // Handle empty response, maybe log or retry
+      }
+      // Only construct string if not empty, or handle empty string case
+      std::string response = "";
+      if (!response_vector.empty()) {
+        response = std::string(response_vector.begin(), response_vector.end());
+      }
+      // Suppress noisy cout during tests, consider logging framework if complex
+      // logs needed std::cout << "Response from MetadataManager: " << response
+      // << std::endl;
+    } catch (const Networking::NetworkException &ne) {
+      std::cerr << "Network error sending message to MetadataManager: "
+                << ne.what() << std::endl;
+    } catch (const std::exception &e) { // Catching other potential exceptions
+      std::cerr << "Error sending message to MetadataManager: " << e.what()
+                << std::endl;
+    }
+  }
 
 private:
-    /**
-     * @brief Periodically sends heartbeat messages to the MetadataManager.
-     * This method runs in a separate thread.
-     * @param metadataManagerAddress The IP address or hostname of the MetadataManager.
-     * @param metadataManagerPort The port number of the MetadataManager.
-     * @param intervalSeconds The interval in seconds at which to send heartbeats.
-     */
-    void sendHeartbeatPeriodically(const std::string& metadataManagerAddress, int metadataManagerPort, int intervalSeconds) {
-        while (true) { // Or use a running flag to control the loop
-            Message msg;
-            msg._Type = MessageType::Heartbeat;
-            msg._Filename = this->nodeName; // Using _Filename to carry the node identifier
+  /**
+   * @brief Periodically sends heartbeat messages to the MetadataManager.
+   * This method runs in a separate thread.
+   * @param metadataManagerAddress The IP address or hostname of the
+   * MetadataManager.
+   * @param metadataManagerPort The port number of the MetadataManager.
+   * @param intervalSeconds The interval in seconds at which to send heartbeats.
+   */
+  void sendHeartbeatPeriodically(const std::string &metadataManagerAddress,
+                                 int metadataManagerPort, int intervalSeconds) {
+    while (true) { // Or use a running flag to control the loop
+      Message msg;
+      msg._Type = MessageType::Heartbeat;
+      msg._Filename =
+          this->nodeName; // Using _Filename to carry the node identifier
 
-            // This function would make a network call to the MetadataManager
-            sendMessageToMetadataManager(metadataManagerAddress, metadataManagerPort, msg);
-            // std::cout << "Node " << nodeName << " sent heartbeat to MetadataManager." << std::endl; // Optional: for debugging
+      // This function would make a network call to the MetadataManager
+      sendMessageToMetadataManager(metadataManagerAddress, metadataManagerPort,
+                                   msg);
+      // std::cout << "Node " << nodeName << " sent heartbeat to
+      // MetadataManager." << std::endl; // Optional: for debugging
 
-            std::this_thread::sleep_for(std::chrono::seconds(intervalSeconds));
-        }
+      std::this_thread::sleep_for(std::chrono::seconds(intervalSeconds));
     }
+  }
 };

--- a/include/utilities/filesystem.h
+++ b/include/utilities/filesystem.h
@@ -2,144 +2,174 @@
 #ifndef _SIMPLIDFS_FILESYSTEM_H
 #define _SIMPLIDFS_FILESYSTEM_H
 
-#include <string>
-#include <vector> // Required for std::vector
 #include <cstddef> // Required for std::byte
+#include <mutex>   // Required for std::mutex and std::unique_lock
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
-#include <mutex> // Required for std::mutex and std::unique_lock
-// #include "utilities/blockio.hpp" // Forward declare or include only in .cpp if possible
+#include <vector> // Required for std::vector
+// #include "utilities/blockio.hpp" // Forward declare or include only in .cpp
+// if possible
 
 /**
  * @brief Manages an in-memory file system for storing file content.
- * 
+ *
  * This class provides basic file operations such as creating, writing, reading,
- * and deleting files. All operations are thread-safe through the use of a mutex.
- * File content is stored as strings in an unordered map.
+ * and deleting files. All operations are thread-safe through the use of a
+ * mutex. File content is stored as strings in an unordered map.
  */
 class FileSystem {
 public:
-    /**
-     * @brief Creates a new, empty file in the file system.
-     * If the file already exists, the operation fails.
-     * @param _pFilename The name of the file to create.
-     * @return True if the file was successfully created, false otherwise (e.g., if it already exists).
-     */
-    bool createFile(const std::string& _pFilename);
+  /**
+   * @brief Creates a new, empty file in the file system.
+   * If the file already exists, the operation fails.
+   * @param _pFilename The name of the file to create.
+   * @return True if the file was successfully created, false otherwise (e.g.,
+   * if it already exists).
+   */
+  bool createFile(const std::string &_pFilename);
 
   /**
    * @brief Renames a file in the file system.
-   * If the old file does not exist or the new file already exists, the operation fails.
+   * If the old file does not exist or the new file already exists, the
+   * operation fails.
    * @param _pOldFilename The current name of the file.
    * @param _pNewFilename The new name for the file.
    * @return True if the file was successfully renamed, false otherwise.
    */
-  bool renameFile(const std::string& _pOldFilename, const std::string& _pNewFilename);
+  bool renameFile(const std::string &_pOldFilename,
+                  const std::string &_pNewFilename);
 
-    /**
-     * @brief Writes content to an existing file.
-     * If the file does not exist, the operation fails. The existing content is overwritten.
-     * @param _pFilename The name of the file to write to.
-     * @param _pContent The content to write into the file.
-     * @return True if the content was successfully written, false otherwise (e.g., if the file does not exist).
-     */
-    bool writeFile(const std::string& _pFilename, const std::string& _pContent);
+  /**
+   * @brief Writes content to an existing file.
+   * If the file does not exist, the operation fails. The existing content is
+   * overwritten.
+   * @param _pFilename The name of the file to write to.
+   * @param _pContent The content to write into the file.
+   * @return True if the content was successfully written, false otherwise
+   * (e.g., if the file does not exist).
+   */
+  bool writeFile(const std::string &_pFilename, const std::string &_pContent);
 
-    /**
-     * @brief Reads the content of an existing file.
-     * If the file does not exist, an empty string is returned.
-     * @param _pFilename The name of the file to read from.
-     * @return A string containing the file's content, or an empty string if the file does not exist.
-     */
-    std::string readFile(const std::string& _pFilename);
+  /**
+   * @brief Reads the content of an existing file.
+   * If the file does not exist, an empty string is returned.
+   * @param _pFilename The name of the file to read from.
+   * @return A string containing the file's content, or an empty string if the
+   * file does not exist.
+   */
+  std::string readFile(const std::string &_pFilename);
 
-    /**
-     * @brief Deletes a file from the file system.
-     * If the file exists, it is removed.
-     * @param _pFilename The name of the file to delete.
-     * @return True if the file was successfully deleted. Returns false if the file did not exist.
-     */
-    bool deleteFile(const std::string& _pFilename);
+  /**
+   * @brief Deletes a file from the file system.
+   * If the file exists, it is removed.
+   * @param _pFilename The name of the file to delete.
+   * @return True if the file was successfully deleted. Returns false if the
+   * file did not exist.
+   */
+  bool deleteFile(const std::string &_pFilename);
 
-    /**
-     * @brief Sets an extended attribute for a file.
-     * @param filename The name of the file.
-     * @param attrName The name of the attribute.
-     * @param attrValue The value of the attribute.
-     */
-    void setXattr(const std::string& filename, const std::string& attrName, const std::string& attrValue);
+  /**
+   * @brief Sets an extended attribute for a file.
+   * @param filename The name of the file.
+   * @param attrName The name of the attribute.
+   * @param attrValue The value of the attribute.
+   */
+  void setXattr(const std::string &filename, const std::string &attrName,
+                const std::string &attrValue);
 
-    /**
-     * @brief Gets an extended attribute for a file.
-     * @param filename The name of the file.
-     * @param attrName The name of the attribute.
-     * @return The value of the attribute, or an empty string if not found.
-     */
-    std::string getXattr(const std::string& filename, const std::string& attrName);
+  /**
+   * @brief Gets an extended attribute for a file.
+   * @param filename The name of the file.
+   * @param attrName The name of the attribute.
+   * @return The value of the attribute, or an empty string if not found.
+   */
+  std::string getXattr(const std::string &filename,
+                       const std::string &attrName);
 
-    /**
-     * @brief Checks if a file exists in the file system.
-     * @param _pFilename The name of the file to check.
-     * @return True if the file exists, false otherwise.
-     */
-    bool fileExists(const std::string& _pFilename) const;
+  /**
+   * @brief Checks if a file exists in the file system.
+   * @param _pFilename The name of the file to check.
+   * @return True if the file exists, false otherwise.
+   */
+  bool fileExists(const std::string &_pFilename) const;
 
-    /**
-     * @brief Create a snapshot of the current filesystem state.
-     * @param name Identifier for the snapshot.
-     * @return True if the snapshot was created, false if a snapshot with the
-     *         same name already exists.
-     */
-    bool snapshotCreate(const std::string& name);
+  /**
+   * @brief List all filenames currently stored in the filesystem.
+   */
+  std::vector<std::string> listFiles() const;
 
-    /**
-     * @brief List available snapshot names.
-     */
-    std::vector<std::string> snapshotList() const;
+  /**
+   * @brief Verify stored data against the hashed CID.
+   * @return True if file data matches stored CID metadata.
+   */
+  bool verifyFileIntegrity(const std::string &filename) const;
 
-    /**
-     * @brief Replace current filesystem state with the contents of a snapshot.
-     * @param name The snapshot name to restore.
-     * @return True if successful, false if the snapshot does not exist.
-     */
-    bool snapshotCheckout(const std::string& name);
+  /**
+   * @brief Create a snapshot of the current filesystem state.
+   * @param name Identifier for the snapshot.
+   * @return True if the snapshot was created, false if a snapshot with the
+   *         same name already exists.
+   */
+  bool snapshotCreate(const std::string &name);
 
-    /**
-     * @brief Show differences between a snapshot and the current state.
-     * @param name The snapshot to compare against.
-     * @return List of textual descriptions of differences.
-     */
-    std::vector<std::string> snapshotDiff(const std::string& name) const;
+  /**
+   * @brief List available snapshot names.
+   */
+  std::vector<std::string> snapshotList() const;
 
-    // Return set of all CIDs referenced by files and snapshots
-    std::unordered_set<std::string> getAllCids() const;
+  /**
+   * @brief Replace current filesystem state with the contents of a snapshot.
+   * @param name The snapshot name to restore.
+   * @return True if successful, false if the snapshot does not exist.
+   */
+  bool snapshotCheckout(const std::string &name);
 
-    /**
-     * @brief Export a snapshot as an IPLD CAR file.
-     * @param name The snapshot name to export.
-     * @param carPath Destination path for the CAR file.
-     * @return True on success, false if the snapshot does not exist or on I/O error.
-     */
-    bool snapshotExportCar(const std::string& name, const std::string& carPath) const;
+  /**
+   * @brief Show differences between a snapshot and the current state.
+   * @param name The snapshot to compare against.
+   * @return List of textual descriptions of differences.
+   */
+  std::vector<std::string> snapshotDiff(const std::string &name) const;
+
+  // Return set of all CIDs referenced by files and snapshots
+  std::unordered_set<std::string> getAllCids() const;
+
+  /**
+   * @brief Export a snapshot as an IPLD CAR file.
+   * @param name The snapshot name to export.
+   * @param carPath Destination path for the CAR file.
+   * @return True on success, false if the snapshot does not exist or on I/O
+   * error.
+   */
+  bool snapshotExportCar(const std::string &name,
+                         const std::string &carPath) const;
 
 private:
-    /**
-     * @brief In-memory storage for files, mapping filename to its content (now binary).
-     */
-    std::unordered_map<std::string, std::vector<std::byte>> _Files;
-    std::unordered_map<std::string, std::unordered_map<std::string, std::string>> _FileXattrs;
+  /**
+   * @brief In-memory storage for files, mapping filename to its content (now
+   * binary).
+   */
+  std::unordered_map<std::string, std::vector<std::byte>> _Files;
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+      _FileXattrs;
 
-    /// Stored snapshots of file data
-    std::unordered_map<std::string, std::unordered_map<std::string, std::vector<std::byte>>> _Snapshots;
-    /// Stored snapshots of xattr metadata
-    std::unordered_map<std::string, std::unordered_map<std::string, std::unordered_map<std::string, std::string>>> _SnapshotXattrs;
+  /// Stored snapshots of file data
+  std::unordered_map<std::string,
+                     std::unordered_map<std::string, std::vector<std::byte>>>
+      _Snapshots;
+  /// Stored snapshots of xattr metadata
+  std::unordered_map<
+      std::string,
+      std::unordered_map<std::string,
+                         std::unordered_map<std::string, std::string>>>
+      _SnapshotXattrs;
 
-    /**
-     * @brief Mutex to protect the _Files map, ensuring thread-safe access to file data.
-     * All public methods acquire this mutex before accessing _Files.
-     */
-    mutable std::mutex _Mutex;
+  /**
+   * @brief Mutex to protect the _Files map, ensuring thread-safe access to file
+   * data. All public methods acquire this mutex before accessing _Files.
+   */
+  mutable std::mutex _Mutex;
 };
-
 
 #endif

--- a/src/utilities/filesystem.cpp
+++ b/src/utilities/filesystem.cpp
@@ -1,414 +1,531 @@
 #include "utilities/filesystem.h"
-#include "utilities/logger.h" // Include the Logger header
 #include "utilities/blockio.hpp" // Already in .h, but good for explicitness or if .h changes
-#include "utilities/cid_utils.hpp" // For digest_to_cid, though BlockIO handles it internally
 #include "utilities/chunk_store.hpp"
+#include "utilities/cid_utils.hpp" // For digest_to_cid, though BlockIO handles it internally
+#include "utilities/logger.h" // Include the Logger header
 #include "utilities/merkle_tree.hpp"
 
+#include <algorithm> // For std::copy, std::transform
+#include <cstddef>   // For std::byte
+#include <fstream>   // For file output
+#include <iterator>  // For std::back_inserter
+#include <map>
+#include <stdexcept> // For std::runtime_error
 #include <string>
 #include <vector>
-#include <cstddef> // For std::byte
-#include <stdexcept> // For std::runtime_error
-#include <algorithm> // For std::copy, std::transform
-#include <iterator>  // For std::back_inserter
-#include <fstream>   // For file output
-#include <map>
 
 // Helper function to convert string to vector<byte>
-inline std::vector<std::byte> string_to_bytes(const std::string& str) {
-    std::vector<std::byte> bytes(str.size());
-    std::transform(str.begin(), str.end(), bytes.begin(), [](char c) {
-        return static_cast<std::byte>(c);
-    });
-    return bytes;
+inline std::vector<std::byte> string_to_bytes(const std::string &str) {
+  std::vector<std::byte> bytes(str.size());
+  std::transform(str.begin(), str.end(), bytes.begin(),
+                 [](char c) { return static_cast<std::byte>(c); });
+  return bytes;
 }
 
 // Helper function to convert vector<byte> to string
-inline std::string bytes_to_string(const std::vector<std::byte>& bytes) {
-    std::string str(bytes.size(), '\0');
-    std::transform(bytes.begin(), bytes.end(), str.begin(), [](std::byte b) {
-        return static_cast<char>(b);
-    });
-    return str;
+inline std::string bytes_to_string(const std::vector<std::byte> &bytes) {
+  std::string str(bytes.size(), '\0');
+  std::transform(bytes.begin(), bytes.end(), str.begin(),
+                 [](std::byte b) { return static_cast<char>(b); });
+  return str;
 }
 
-
-bool FileSystem::createFile(const std::string& _pFilename)
-{
-	std::unique_lock<std::mutex> lock(_Mutex);
-	if(_Files.count(_pFilename)) {
-        Logger::getInstance().log(LogLevel::WARN, "Attempted to create file that already exists: " + _pFilename);
-		return false;
-    }
-	_Files[_pFilename] = {}; // Store empty vector<byte>
-    Logger::getInstance().log(LogLevel::INFO, "File created: " + _pFilename);
-	return true;
-		
+bool FileSystem::createFile(const std::string &_pFilename) {
+  std::unique_lock<std::mutex> lock(_Mutex);
+  if (_Files.count(_pFilename)) {
+    Logger::getInstance().log(LogLevel::WARN,
+                              "Attempted to create file that already exists: " +
+                                  _pFilename);
+    return false;
+  }
+  _Files[_pFilename] = {}; // Store empty vector<byte>
+  Logger::getInstance().log(LogLevel::INFO, "File created: " + _pFilename);
+  return true;
 }
 
+bool FileSystem::writeFile(const std::string &_pFilename,
+                           const std::string &_pContent) {
+  std::unique_lock<std::mutex> lock(_Mutex);
+  if (!_Files.count(_pFilename)) {
+    Logger::getInstance().log(LogLevel::ERROR,
+                              "Attempted to write to non-existent file: " +
+                                  _pFilename);
+    return false;
+  }
 
-bool FileSystem::writeFile(const std::string& _pFilename, const std::string& _pContent)
-{
-	std::unique_lock<std::mutex> lock(_Mutex);
-	if(!_Files.count(_pFilename)) {
-        Logger::getInstance().log(LogLevel::ERROR, "Attempted to write to non-existent file: " + _pFilename);
-		return false;
-    }
+  try {
+    BlockIO localBlockIO; // Create a local BlockIO instance for this operation
 
-    try {
-        BlockIO localBlockIO; // Create a local BlockIO instance for this operation
+    // 1. Convert content to std::vector<std::byte>
+    std::vector<std::byte> rawData = string_to_bytes(_pContent);
 
-        // 1. Convert content to std::vector<std::byte>
-        std::vector<std::byte> rawData = string_to_bytes(_pContent);
+    // 2. Ingest raw data for hashing and get CID
+    // Create a separate BlockIO for hashing to ensure clean state if needed,
+    // though ingest/finalize_hashed on the same localBlockIO should be fine if
+    // it resets or is single-use. For safety, let's assume BlockIO's
+    // finalize_hashed might leave it in a state not suitable for further data
+    // processing operations like encrypt/compress on its internal buffer. The
+    // current BlockIO API takes data as parameter for encrypt/compress, so it's
+    // fine.
+    BlockIO hasher;
+    hasher.ingest(rawData.data(), rawData.size());
+    DigestResult hashResult = hasher.finalize_hashed();
+    std::string cid = hashResult.cid;
 
-        // 2. Ingest raw data for hashing and get CID
-        // Create a separate BlockIO for hashing to ensure clean state if needed,
-        // though ingest/finalize_hashed on the same localBlockIO should be fine if it resets or is single-use.
-        // For safety, let's assume BlockIO's finalize_hashed might leave it in a state
-        // not suitable for further data processing operations like encrypt/compress on its internal buffer.
-        // The current BlockIO API takes data as parameter for encrypt/compress, so it's fine.
-        BlockIO hasher;
-        hasher.ingest(rawData.data(), rawData.size());
-        DigestResult hashResult = hasher.finalize_hashed();
-        std::string cid = hashResult.cid;
+    // 3. Define placeholder encryption key
+    std::array<unsigned char, crypto_aead_aes256gcm_KEYBYTES> key;
+    key.fill('A'); // Placeholder - MUST be replaced with proper key management
 
-        // 3. Define placeholder encryption key
-        std::array<unsigned char, crypto_aead_aes256gcm_KEYBYTES> key;
-        key.fill('A'); // Placeholder - MUST be replaced with proper key management
+    // 4. Encrypt the raw data
+    std::vector<unsigned char> nonce;
+    std::vector<std::byte> encryptedData =
+        localBlockIO.encrypt_data(rawData, key, nonce);
 
-        // 4. Encrypt the raw data
-        std::vector<unsigned char> nonce;
-        std::vector<std::byte> encryptedData = localBlockIO.encrypt_data(rawData, key, nonce);
+    // 5. Compress the encrypted data
+    std::vector<std::byte> compressedData =
+        localBlockIO.compress_data(encryptedData);
 
-        // 5. Compress the encrypted data
-        std::vector<std::byte> compressedData = localBlockIO.compress_data(encryptedData);
+    // 6. Store compressed data
+    _Files[_pFilename] = compressedData;
 
-        // 6. Store compressed data
-        _Files[_pFilename] = compressedData;
+    // 7. Store metadata
+    setXattr(_pFilename, "user.cid", cid);
+    // Convert nonce to a string for storage (e.g., hex or base64, here simple
+    // char conversion)
+    std::string nonce_str;
+    nonce_str.reserve(nonce.size());
+    for (unsigned char uc : nonce) {
+      nonce_str.push_back(static_cast<char>(uc));
+    } // Simple byte to char
+    setXattr(_pFilename, "user.nonce", nonce_str);
+    setXattr(_pFilename, "user.original_size", std::to_string(rawData.size()));
+    setXattr(_pFilename, "user.encrypted_size",
+             std::to_string(encryptedData.size()));
 
-        // 7. Store metadata
-        setXattr(_pFilename, "user.cid", cid);
-        // Convert nonce to a string for storage (e.g., hex or base64, here simple char conversion)
-        std::string nonce_str;
-        nonce_str.reserve(nonce.size());
-        for(unsigned char uc : nonce) { nonce_str.push_back(static_cast<char>(uc)); } // Simple byte to char
-        setXattr(_pFilename, "user.nonce", nonce_str);
-        setXattr(_pFilename, "user.original_size", std::to_string(rawData.size()));
-        setXattr(_pFilename, "user.encrypted_size", std::to_string(encryptedData.size()));
-
-        Logger::getInstance().log(LogLevel::INFO, "File written with encryption/compression: " + _pFilename + ", CID: " + cid);
-        return true;
-
-    } catch (const std::exception& e) {
-        Logger::getInstance().log(LogLevel::ERROR, "FileSystem::writeFile failed for " + _pFilename + ": " + e.what());
-        // Potentially revert changes or mark file as corrupted if partial write occurred.
-        // For now, just return false. If _Files[_pFilename] was updated, it might hold partial data.
-        // A robust implementation might remove _Files[_pFilename] or store its old value.
-        return false;
-    }
-}
-
-
-std::string FileSystem::readFile(const std::string& _pFilename)
-{
-	std::unique_lock<std::mutex> lock(_Mutex);
-	if(!_Files.count(_pFilename)) {
-        Logger::getInstance().log(LogLevel::ERROR, "Attempted to read non-existent file: " + _pFilename);
-		return "";
-    }
-
-    try {
-        const std::vector<std::byte>& compressedData = _Files.at(_pFilename);
-        if (compressedData.empty() && getXattr(_pFilename, "user.cid").empty()) {
-             // If it's an empty file created by createFile, it has no xattrs and empty data.
-            Logger::getInstance().log(LogLevel::INFO, "File read (empty, as created): " + _pFilename);
-            return "";
-        }
-
-
-        // 1. Retrieve metadata
-        std::string cid = getXattr(_pFilename, "user.cid");
-        std::string nonce_str = getXattr(_pFilename, "user.nonce");
-        std::string original_size_str = getXattr(_pFilename, "user.original_size");
-        std::string encrypted_size_str = getXattr(_pFilename, "user.encrypted_size");
-
-        if (cid.empty() || nonce_str.empty() || original_size_str.empty() || encrypted_size_str.empty()) {
-            Logger::getInstance().log(LogLevel::ERROR, "Missing metadata for file: " + _pFilename);
-            // This might be an old file not written with the new pipeline, or corruption.
-            // Depending on policy, could return raw data if available and no CID, or error.
-            // For now, assume if metadata is missing, it's an error for this pipeline.
-            // If any critical metadata is missing, we cannot proceed with the new pipeline.
-            Logger::getInstance().log(LogLevel::ERROR, "File " + _pFilename + " is missing critical pipeline metadata (cid, nonce, original_size, or encrypted_size). Cannot process as new format.");
-            throw std::runtime_error("Missing required metadata for new format decryption/decompression.");
-        }
-
-        // Convert nonce string (raw bytes) to vector<unsigned char>
-        std::vector<unsigned char> nonce(nonce_str.length());
-        std::transform(nonce_str.begin(), nonce_str.end(), nonce.begin(), [](char c){
-            return static_cast<unsigned char>(c);
-        });
-
-        // size_t original_raw_size = std::stoul(original_size_str); // size of original plaintext data
-        size_t encrypted_size = std::stoul(encrypted_size_str); // size of data before compression (i.e. encrypted data size)
-
-
-        // 2. Define placeholder encryption key (must match writeFile)
-        std::array<unsigned char, crypto_aead_aes256gcm_KEYBYTES> key;
-        key.fill('A'); // Placeholder
-
-        BlockIO localBlockIO; // Create a local BlockIO instance
-
-        // 3. Decompress the data
-        // The 'original_size' for decompress_data here is the size of the data *before* compression,
-        // which is the encrypted_size.
-        std::vector<std::byte> decompressedEncryptedData = localBlockIO.decompress_data(compressedData, encrypted_size);
-
-        // 4. Decrypt the data
-        std::vector<std::byte> decryptedRawData = localBlockIO.decrypt_data(decompressedEncryptedData, key, nonce);
-
-        // 5. Verify the hash (CID)
-        BlockIO hashVerifierBlockIO;
-        hashVerifierBlockIO.ingest(decryptedRawData.data(), decryptedRawData.size());
-        DigestResult verificationResult = hashVerifierBlockIO.finalize_hashed();
-        if (verificationResult.cid != cid) {
-            Logger::getInstance().log(LogLevel::ERROR, "CID mismatch after decryption for file: " + _pFilename + ". Expected: " + cid + ", Got: " + verificationResult.cid);
-            throw std::runtime_error("CID mismatch after decryption! Data may be corrupted or key is wrong.");
-        }
-
-        Logger::getInstance().log(LogLevel::INFO, "File read with decryption/decompression: " + _pFilename + ", CID: " + cid);
-
-        // 6. Convert decrypted data to string and return
-        return bytes_to_string(decryptedRawData);
-
-    } catch (const std::exception& e) {
-        Logger::getInstance().log(LogLevel::ERROR, "FileSystem::readFile failed for " + _pFilename + ": " + e.what());
-        return ""; // Return empty string on error
-    }
-}
-
-bool FileSystem::deleteFile(const std::string& _pFilename) {
-    std::unique_lock<std::mutex> lock(_Mutex);
-    if (_Files.count(_pFilename)) {
-        _Files.erase(_pFilename);
-        _FileXattrs.erase(_pFilename); // Also remove associated xattrs
-        Logger::getInstance().log(LogLevel::INFO, "File deleted: " + _pFilename);
-        return true; // Successfully deleted
-    }
-    Logger::getInstance().log(LogLevel::WARN, "Attempted to delete non-existent file: " + _pFilename);
-    return false; // File did not exist
-}
-
-bool FileSystem::renameFile(const std::string& _pOldFilename, const std::string& _pNewFilename) {
-    std::unique_lock<std::mutex> lock(_Mutex);
-    if (_Files.find(_pOldFilename) == _Files.end()) {
-        Logger::getInstance().log(LogLevel::WARN, "Attempted to rename non-existent file: " + _pOldFilename);
-        return false; // Old file doesn't exist
-    }
-    if (_Files.find(_pNewFilename) != _Files.end()) {
-        // Overwriting an existing file via rename is typically disallowed or requires a special flag.
-        // For now, let's disallow to prevent accidental data loss.
-        Logger::getInstance().log(LogLevel::WARN, "Attempted to rename to an already existing file: " + _pNewFilename);
-        return false; // New file already exists
-    }
-
-    // Perform the rename for file content
-    _Files[_pNewFilename] = std::move(_Files[_pOldFilename]);
-    _Files.erase(_pOldFilename);
-
-    // Transfer xattrs
-    if (_FileXattrs.count(_pOldFilename)) {
-        _FileXattrs[_pNewFilename] = std::move(_FileXattrs[_pOldFilename]);
-        _FileXattrs.erase(_pOldFilename);
-    }
-
-    Logger::getInstance().log(LogLevel::INFO, "File renamed from " + _pOldFilename + " to " + _pNewFilename);
+    Logger::getInstance().log(LogLevel::INFO,
+                              "File written with encryption/compression: " +
+                                  _pFilename + ", CID: " + cid);
     return true;
+
+  } catch (const std::exception &e) {
+    Logger::getInstance().log(LogLevel::ERROR,
+                              "FileSystem::writeFile failed for " + _pFilename +
+                                  ": " + e.what());
+    // Potentially revert changes or mark file as corrupted if partial write
+    // occurred. For now, just return false. If _Files[_pFilename] was updated,
+    // it might hold partial data. A robust implementation might remove
+    // _Files[_pFilename] or store its old value.
+    return false;
+  }
 }
 
-void FileSystem::setXattr(const std::string& filename, const std::string& attrName, const std::string& attrValue) {
-    // This function is called internally by writeFile which already holds the lock and ensures file exists in _Files.
-    if (_Files.find(filename) == _Files.end()) {
-        // This check is a safeguard. Under normal operation by writeFile, file should exist.
-        Logger::getInstance().log(LogLevel::ERROR, "FileSystem::setXattr called for a file not in _Files: " + filename);
-        return;
-    }
-    _FileXattrs[filename][attrName] = attrValue;
-    // Logger::getInstance().log(LogLevel::DEBUG, "xattr set for file: " + filename + ", Attribute: " + attrName);
-}
-
-std::string FileSystem::getXattr(const std::string& filename, const std::string& attrName) {
-    // This function is called internally by readFile which already holds the lock.
-    auto it = _FileXattrs.find(filename);
-    if (it != _FileXattrs.end()) {
-        auto attrIt = it->second.find(attrName);
-        if (attrIt != it->second.end()) {
-            // Logger::getInstance().log(LogLevel::INFO, "xattr retrieved for file: " + filename + ", Attribute: " + attrName);
-            return attrIt->second;
-        }
-    }
-    // Logger::getInstance().log(LogLevel::INFO, "xattr not found for file: " + filename + ", Attribute: " + attrName);
+std::string FileSystem::readFile(const std::string &_pFilename) {
+  std::unique_lock<std::mutex> lock(_Mutex);
+  if (!_Files.count(_pFilename)) {
+    Logger::getInstance().log(
+        LogLevel::ERROR, "Attempted to read non-existent file: " + _pFilename);
     return "";
-}
+  }
 
-bool FileSystem::fileExists(const std::string& _pFilename) const {
-    std::lock_guard<std::mutex> lock(_Mutex); // _Mutex is now mutable in the header
-    return _Files.count(_pFilename);
-}
-
-bool FileSystem::snapshotCreate(const std::string& name) {
-    std::lock_guard<std::mutex> lock(_Mutex);
-    if (_Snapshots.count(name)) {
-        return false;
+  try {
+    const std::vector<std::byte> &compressedData = _Files.at(_pFilename);
+    if (compressedData.empty() && getXattr(_pFilename, "user.cid").empty()) {
+      // If it's an empty file created by createFile, it has no xattrs and empty
+      // data.
+      Logger::getInstance().log(LogLevel::INFO,
+                                "File read (empty, as created): " + _pFilename);
+      return "";
     }
-    _Snapshots[name] = _Files;
-    _SnapshotXattrs[name] = _FileXattrs;
-    return true;
+
+    // 1. Retrieve metadata
+    std::string cid = getXattr(_pFilename, "user.cid");
+    std::string nonce_str = getXattr(_pFilename, "user.nonce");
+    std::string original_size_str = getXattr(_pFilename, "user.original_size");
+    std::string encrypted_size_str =
+        getXattr(_pFilename, "user.encrypted_size");
+
+    if (cid.empty() || nonce_str.empty() || original_size_str.empty() ||
+        encrypted_size_str.empty()) {
+      Logger::getInstance().log(LogLevel::ERROR,
+                                "Missing metadata for file: " + _pFilename);
+      // This might be an old file not written with the new pipeline, or
+      // corruption. Depending on policy, could return raw data if available and
+      // no CID, or error. For now, assume if metadata is missing, it's an error
+      // for this pipeline. If any critical metadata is missing, we cannot
+      // proceed with the new pipeline.
+      Logger::getInstance().log(
+          LogLevel::ERROR, "File " + _pFilename +
+                               " is missing critical pipeline metadata (cid, "
+                               "nonce, original_size, or encrypted_size). "
+                               "Cannot process as new format.");
+      throw std::runtime_error(
+          "Missing required metadata for new format decryption/decompression.");
+    }
+
+    // Convert nonce string (raw bytes) to vector<unsigned char>
+    std::vector<unsigned char> nonce(nonce_str.length());
+    std::transform(nonce_str.begin(), nonce_str.end(), nonce.begin(),
+                   [](char c) { return static_cast<unsigned char>(c); });
+
+    // size_t original_raw_size = std::stoul(original_size_str); // size of
+    // original plaintext data
+    size_t encrypted_size =
+        std::stoul(encrypted_size_str); // size of data before compression (i.e.
+                                        // encrypted data size)
+
+    // 2. Define placeholder encryption key (must match writeFile)
+    std::array<unsigned char, crypto_aead_aes256gcm_KEYBYTES> key;
+    key.fill('A'); // Placeholder
+
+    BlockIO localBlockIO; // Create a local BlockIO instance
+
+    // 3. Decompress the data
+    // The 'original_size' for decompress_data here is the size of the data
+    // *before* compression, which is the encrypted_size.
+    std::vector<std::byte> decompressedEncryptedData =
+        localBlockIO.decompress_data(compressedData, encrypted_size);
+
+    // 4. Decrypt the data
+    std::vector<std::byte> decryptedRawData =
+        localBlockIO.decrypt_data(decompressedEncryptedData, key, nonce);
+
+    // 5. Verify the hash (CID)
+    BlockIO hashVerifierBlockIO;
+    hashVerifierBlockIO.ingest(decryptedRawData.data(),
+                               decryptedRawData.size());
+    DigestResult verificationResult = hashVerifierBlockIO.finalize_hashed();
+    if (verificationResult.cid != cid) {
+      Logger::getInstance().log(
+          LogLevel::ERROR,
+          "CID mismatch after decryption for file: " + _pFilename +
+              ". Expected: " + cid + ", Got: " + verificationResult.cid);
+      throw std::runtime_error("CID mismatch after decryption! Data may be "
+                               "corrupted or key is wrong.");
+    }
+
+    Logger::getInstance().log(LogLevel::INFO,
+                              "File read with decryption/decompression: " +
+                                  _pFilename + ", CID: " + cid);
+
+    // 6. Convert decrypted data to string and return
+    return bytes_to_string(decryptedRawData);
+
+  } catch (const std::exception &e) {
+    Logger::getInstance().log(LogLevel::ERROR,
+                              "FileSystem::readFile failed for " + _pFilename +
+                                  ": " + e.what());
+    return ""; // Return empty string on error
+  }
+}
+
+bool FileSystem::deleteFile(const std::string &_pFilename) {
+  std::unique_lock<std::mutex> lock(_Mutex);
+  if (_Files.count(_pFilename)) {
+    _Files.erase(_pFilename);
+    _FileXattrs.erase(_pFilename); // Also remove associated xattrs
+    Logger::getInstance().log(LogLevel::INFO, "File deleted: " + _pFilename);
+    return true; // Successfully deleted
+  }
+  Logger::getInstance().log(
+      LogLevel::WARN, "Attempted to delete non-existent file: " + _pFilename);
+  return false; // File did not exist
+}
+
+bool FileSystem::renameFile(const std::string &_pOldFilename,
+                            const std::string &_pNewFilename) {
+  std::unique_lock<std::mutex> lock(_Mutex);
+  if (_Files.find(_pOldFilename) == _Files.end()) {
+    Logger::getInstance().log(LogLevel::WARN,
+                              "Attempted to rename non-existent file: " +
+                                  _pOldFilename);
+    return false; // Old file doesn't exist
+  }
+  if (_Files.find(_pNewFilename) != _Files.end()) {
+    // Overwriting an existing file via rename is typically disallowed or
+    // requires a special flag. For now, let's disallow to prevent accidental
+    // data loss.
+    Logger::getInstance().log(
+        LogLevel::WARN,
+        "Attempted to rename to an already existing file: " + _pNewFilename);
+    return false; // New file already exists
+  }
+
+  // Perform the rename for file content
+  _Files[_pNewFilename] = std::move(_Files[_pOldFilename]);
+  _Files.erase(_pOldFilename);
+
+  // Transfer xattrs
+  if (_FileXattrs.count(_pOldFilename)) {
+    _FileXattrs[_pNewFilename] = std::move(_FileXattrs[_pOldFilename]);
+    _FileXattrs.erase(_pOldFilename);
+  }
+
+  Logger::getInstance().log(LogLevel::INFO, "File renamed from " +
+                                                _pOldFilename + " to " +
+                                                _pNewFilename);
+  return true;
+}
+
+void FileSystem::setXattr(const std::string &filename,
+                          const std::string &attrName,
+                          const std::string &attrValue) {
+  // This function is called internally by writeFile which already holds the
+  // lock and ensures file exists in _Files.
+  if (_Files.find(filename) == _Files.end()) {
+    // This check is a safeguard. Under normal operation by writeFile, file
+    // should exist.
+    Logger::getInstance().log(
+        LogLevel::ERROR,
+        "FileSystem::setXattr called for a file not in _Files: " + filename);
+    return;
+  }
+  _FileXattrs[filename][attrName] = attrValue;
+  // Logger::getInstance().log(LogLevel::DEBUG, "xattr set for file: " +
+  // filename + ", Attribute: " + attrName);
+}
+
+std::string FileSystem::getXattr(const std::string &filename,
+                                 const std::string &attrName) {
+  // This function is called internally by readFile which already holds the
+  // lock.
+  auto it = _FileXattrs.find(filename);
+  if (it != _FileXattrs.end()) {
+    auto attrIt = it->second.find(attrName);
+    if (attrIt != it->second.end()) {
+      // Logger::getInstance().log(LogLevel::INFO, "xattr retrieved for file: "
+      // + filename + ", Attribute: " + attrName);
+      return attrIt->second;
+    }
+  }
+  // Logger::getInstance().log(LogLevel::INFO, "xattr not found for file: " +
+  // filename + ", Attribute: " + attrName);
+  return "";
+}
+
+bool FileSystem::fileExists(const std::string &_pFilename) const {
+  std::lock_guard<std::mutex> lock(
+      _Mutex); // _Mutex is now mutable in the header
+  return _Files.count(_pFilename);
+}
+
+std::vector<std::string> FileSystem::listFiles() const {
+  std::lock_guard<std::mutex> lock(_Mutex);
+  std::vector<std::string> names;
+  for (const auto &kv : _Files) {
+    names.push_back(kv.first);
+  }
+  return names;
+}
+
+bool FileSystem::verifyFileIntegrity(const std::string &filename) const {
+  std::lock_guard<std::mutex> lock(_Mutex);
+  auto it = _Files.find(filename);
+  if (it == _Files.end())
+    return false;
+
+  const auto &compressedData = it->second;
+  auto attrIt = _FileXattrs.find(filename);
+  if (attrIt == _FileXattrs.end()) {
+    return compressedData.empty();
+  }
+
+  const auto &attrs = attrIt->second;
+  auto cidIt = attrs.find("user.cid");
+  auto nonceIt = attrs.find("user.nonce");
+  auto encIt = attrs.find("user.encrypted_size");
+  if (cidIt == attrs.end() || nonceIt == attrs.end() || encIt == attrs.end()) {
+    return false;
+  }
+
+  std::string cid = cidIt->second;
+  std::string nonce_str = nonceIt->second;
+  size_t encrypted_size = 0;
+  try {
+    encrypted_size = std::stoull(encIt->second);
+  } catch (...) {
+    return false;
+  }
+
+  std::vector<unsigned char> nonce(nonce_str.begin(), nonce_str.end());
+  std::array<unsigned char, crypto_aead_aes256gcm_KEYBYTES> key;
+  key.fill('A');
+  BlockIO bio;
+  std::vector<std::byte> decrypted = bio.decrypt_data(
+      bio.decompress_data(compressedData, encrypted_size), key, nonce);
+  BlockIO verify;
+  if (!decrypted.empty())
+    verify.ingest(decrypted.data(), decrypted.size());
+  DigestResult dr = verify.finalize_hashed();
+  return dr.cid == cid;
+}
+
+bool FileSystem::snapshotCreate(const std::string &name) {
+  std::lock_guard<std::mutex> lock(_Mutex);
+  if (_Snapshots.count(name)) {
+    return false;
+  }
+  _Snapshots[name] = _Files;
+  _SnapshotXattrs[name] = _FileXattrs;
+  return true;
 }
 
 std::vector<std::string> FileSystem::snapshotList() const {
-    std::lock_guard<std::mutex> lock(_Mutex);
-    std::vector<std::string> names;
-    for (const auto& kv : _Snapshots) {
-        names.push_back(kv.first);
-    }
-    return names;
+  std::lock_guard<std::mutex> lock(_Mutex);
+  std::vector<std::string> names;
+  for (const auto &kv : _Snapshots) {
+    names.push_back(kv.first);
+  }
+  return names;
 }
 
-bool FileSystem::snapshotCheckout(const std::string& name) {
-    std::lock_guard<std::mutex> lock(_Mutex);
-    auto it = _Snapshots.find(name);
-    if (it == _Snapshots.end()) {
-        return false;
-    }
-    _Files = it->second;
-    _FileXattrs = _SnapshotXattrs[name];
-    return true;
+bool FileSystem::snapshotCheckout(const std::string &name) {
+  std::lock_guard<std::mutex> lock(_Mutex);
+  auto it = _Snapshots.find(name);
+  if (it == _Snapshots.end()) {
+    return false;
+  }
+  _Files = it->second;
+  _FileXattrs = _SnapshotXattrs[name];
+  return true;
 }
 
-std::vector<std::string> FileSystem::snapshotDiff(const std::string& name) const {
-    std::lock_guard<std::mutex> lock(_Mutex);
-    std::vector<std::string> diff;
-    auto it = _Snapshots.find(name);
-    if (it == _Snapshots.end()) {
-        return diff;
-    }
-    const auto& snapFiles = it->second;
-    for (const auto& kv : snapFiles) {
-        const auto& fname = kv.first;
-        if (!_Files.count(fname)) {
-            diff.push_back("Deleted: " + fname);
-        } else if (_Files.at(fname) != kv.second) {
-            diff.push_back("Modified: " + fname);
-        }
-    }
-    for (const auto& kv : _Files) {
-        if (!snapFiles.count(kv.first)) {
-            diff.push_back("Added: " + kv.first);
-        }
-    }
+std::vector<std::string>
+FileSystem::snapshotDiff(const std::string &name) const {
+  std::lock_guard<std::mutex> lock(_Mutex);
+  std::vector<std::string> diff;
+  auto it = _Snapshots.find(name);
+  if (it == _Snapshots.end()) {
     return diff;
+  }
+  const auto &snapFiles = it->second;
+  for (const auto &kv : snapFiles) {
+    const auto &fname = kv.first;
+    if (!_Files.count(fname)) {
+      diff.push_back("Deleted: " + fname);
+    } else if (_Files.at(fname) != kv.second) {
+      diff.push_back("Modified: " + fname);
+    }
+  }
+  for (const auto &kv : _Files) {
+    if (!snapFiles.count(kv.first)) {
+      diff.push_back("Added: " + kv.first);
+    }
+  }
+  return diff;
 }
 
 std::unordered_set<std::string> FileSystem::getAllCids() const {
-    std::lock_guard<std::mutex> lock(_Mutex);
-    std::unordered_set<std::string> cids;
-    for (const auto& [file, attrs] : _FileXattrs) {
-        auto it = attrs.find("user.cid");
-        if (it != attrs.end() && !it->second.empty()) {
-            cids.insert(it->second);
-        }
+  std::lock_guard<std::mutex> lock(_Mutex);
+  std::unordered_set<std::string> cids;
+  for (const auto &[file, attrs] : _FileXattrs) {
+    auto it = attrs.find("user.cid");
+    if (it != attrs.end() && !it->second.empty()) {
+      cids.insert(it->second);
     }
-    for (const auto& [snapName, snapAttrs] : _SnapshotXattrs) {
-        for (const auto& [file, attrs] : snapAttrs) {
-            auto it = attrs.find("user.cid");
-            if (it != attrs.end() && !it->second.empty()) {
-                cids.insert(it->second);
-            }
-        }
+  }
+  for (const auto &[snapName, snapAttrs] : _SnapshotXattrs) {
+    for (const auto &[file, attrs] : snapAttrs) {
+      auto it = attrs.find("user.cid");
+      if (it != attrs.end() && !it->second.empty()) {
+        cids.insert(it->second);
+      }
     }
-    return cids;
+  }
+  return cids;
 }
 
 // Helper: encode unsigned varint (LEB128)
-static void write_uvarint(std::ostream& os, uint64_t value) {
-    while (value >= 0x80) {
-        uint8_t b = static_cast<uint8_t>(value) | 0x80;
-        os.put(static_cast<char>(b));
-        value >>= 7;
-    }
-    os.put(static_cast<char>(value));
+static void write_uvarint(std::ostream &os, uint64_t value) {
+  while (value >= 0x80) {
+    uint8_t b = static_cast<uint8_t>(value) | 0x80;
+    os.put(static_cast<char>(b));
+    value >>= 7;
+  }
+  os.put(static_cast<char>(value));
 }
 
-static bool write_car_file(const std::map<std::string, std::vector<std::byte>>& chunks,
-                           const std::string& rootCid,
-                           const std::string& path) {
-    std::ofstream out(path, std::ios::binary);
-    if (!out.is_open()) return false;
+static bool
+write_car_file(const std::map<std::string, std::vector<std::byte>> &chunks,
+               const std::string &rootCid, const std::string &path) {
+  std::ofstream out(path, std::ios::binary);
+  if (!out.is_open())
+    return false;
 
-    std::vector<uint8_t> rootBytes = sgns::utils::cid_to_bytes(rootCid);
+  std::vector<uint8_t> rootBytes = sgns::utils::cid_to_bytes(rootCid);
 
-    // Build minimal CARv1 header using CBOR encoding
-    std::vector<uint8_t> header;
-    header.push_back(0xa2);                        // map of 2 items
-    header.push_back(0x65); header.insert(header.end(), {'r','o','o','t','s'}); // key "roots"
-    header.push_back(0x81);                        // array[1]
-    header.push_back(0x58); header.push_back(static_cast<uint8_t>(rootBytes.size()));
-    header.insert(header.end(), rootBytes.begin(), rootBytes.end());
-    header.push_back(0x67); header.insert(header.end(), {'v','e','r','s','i','o','n'}); // key "version"
-    header.push_back(0x01);                        // value 1
+  // Build minimal CARv1 header using CBOR encoding
+  std::vector<uint8_t> header;
+  header.push_back(0xa2); // map of 2 items
+  header.push_back(0x65);
+  header.insert(header.end(), {'r', 'o', 'o', 't', 's'}); // key "roots"
+  header.push_back(0x81);                                 // array[1]
+  header.push_back(0x58);
+  header.push_back(static_cast<uint8_t>(rootBytes.size()));
+  header.insert(header.end(), rootBytes.begin(), rootBytes.end());
+  header.push_back(0x67);
+  header.insert(header.end(),
+                {'v', 'e', 'r', 's', 'i', 'o', 'n'}); // key "version"
+  header.push_back(0x01);                             // value 1
 
-    write_uvarint(out, header.size());
-    out.write(reinterpret_cast<const char*>(header.data()), header.size());
+  write_uvarint(out, header.size());
+  out.write(reinterpret_cast<const char *>(header.data()), header.size());
 
-    for (const auto& [cid, data] : chunks) {
-        std::vector<uint8_t> cidBytes = sgns::utils::cid_to_bytes(cid);
-        uint64_t section_len = cidBytes.size() + data.size();
-        write_uvarint(out, section_len);
-        out.write(reinterpret_cast<const char*>(cidBytes.data()), cidBytes.size());
-        out.write(reinterpret_cast<const char*>(data.data()), data.size());
-    }
-    return true;
+  for (const auto &[cid, data] : chunks) {
+    std::vector<uint8_t> cidBytes = sgns::utils::cid_to_bytes(cid);
+    uint64_t section_len = cidBytes.size() + data.size();
+    write_uvarint(out, section_len);
+    out.write(reinterpret_cast<const char *>(cidBytes.data()), cidBytes.size());
+    out.write(reinterpret_cast<const char *>(data.data()), data.size());
+  }
+  return true;
 }
 
-bool FileSystem::snapshotExportCar(const std::string& name, const std::string& carPath) const {
-    std::lock_guard<std::mutex> lock(_Mutex);
-    auto snapIt = _Snapshots.find(name);
-    if (snapIt == _Snapshots.end()) return false;
+bool FileSystem::snapshotExportCar(const std::string &name,
+                                   const std::string &carPath) const {
+  std::lock_guard<std::mutex> lock(_Mutex);
+  auto snapIt = _Snapshots.find(name);
+  if (snapIt == _Snapshots.end())
+    return false;
 
-    auto attrsIt = _SnapshotXattrs.find(name);
-    if (attrsIt == _SnapshotXattrs.end()) return false;
+  auto attrsIt = _SnapshotXattrs.find(name);
+  if (attrsIt == _SnapshotXattrs.end())
+    return false;
 
-    ChunkStore store;
-    std::vector<std::pair<std::string, std::string>> entries;
+  ChunkStore store;
+  std::vector<std::pair<std::string, std::string>> entries;
 
-    for (const auto& [file, data] : snapIt->second) {
-        auto attrMapIt = attrsIt->second.find(file);
-        if (attrMapIt == attrsIt->second.end()) continue;
-        const auto& attrMap = attrMapIt->second;
-        auto cidIt = attrMap.find("user.cid");
-        auto nonceIt = attrMap.find("user.nonce");
-        auto encIt = attrMap.find("user.encrypted_size");
-        if (cidIt == attrMap.end() || nonceIt == attrMap.end() || encIt == attrMap.end()) continue;
+  for (const auto &[file, data] : snapIt->second) {
+    auto attrMapIt = attrsIt->second.find(file);
+    if (attrMapIt == attrsIt->second.end())
+      continue;
+    const auto &attrMap = attrMapIt->second;
+    auto cidIt = attrMap.find("user.cid");
+    auto nonceIt = attrMap.find("user.nonce");
+    auto encIt = attrMap.find("user.encrypted_size");
+    if (cidIt == attrMap.end() || nonceIt == attrMap.end() ||
+        encIt == attrMap.end())
+      continue;
 
-        std::string cid = cidIt->second;
-        std::string nonce_str = nonceIt->second;
-        size_t enc_size = std::stoul(encIt->second);
+    std::string cid = cidIt->second;
+    std::string nonce_str = nonceIt->second;
+    size_t enc_size = std::stoul(encIt->second);
 
-        std::vector<unsigned char> nonce(nonce_str.begin(), nonce_str.end());
-        std::array<unsigned char, crypto_aead_aes256gcm_KEYBYTES> key; key.fill('A');
-        BlockIO local;
-        std::vector<std::byte> decompressed = local.decompress_data(data, enc_size);
-        std::vector<std::byte> raw = local.decrypt_data(decompressed, key, nonce);
-        store.addChunk(raw); // cid should match but ignore
-        entries.emplace_back(file, cid);
-    }
+    std::vector<unsigned char> nonce(nonce_str.begin(), nonce_str.end());
+    std::array<unsigned char, crypto_aead_aes256gcm_KEYBYTES> key;
+    key.fill('A');
+    BlockIO local;
+    std::vector<std::byte> decompressed = local.decompress_data(data, enc_size);
+    std::vector<std::byte> raw = local.decrypt_data(decompressed, key, nonce);
+    store.addChunk(raw); // cid should match but ignore
+    entries.emplace_back(file, cid);
+  }
 
-    std::string rootCid = MerkleTree::hashDirectory(entries, store);
+  std::string rootCid = MerkleTree::hashDirectory(entries, store);
 
-    std::map<std::string, std::vector<std::byte>> orderedChunks;
-    for (const auto& [cid, bytes] : store.getAllChunks()) {
-        orderedChunks[cid] = bytes;
-    }
+  std::map<std::string, std::vector<std::byte>> orderedChunks;
+  for (const auto &[cid, bytes] : store.getAllChunks()) {
+    orderedChunks[cid] = bytes;
+  }
 
-    return write_car_file(orderedChunks, rootCid, carPath);
+  return write_car_file(orderedChunks, rootCid, carPath);
 }

--- a/tests/chaos_kill_node.sh
+++ b/tests/chaos_kill_node.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Chaos test: randomly kill one node every 5 minutes for 2 hours
+set -e
+NODES=(Node1 Node2 Node3)
+DURATION=$((2*60*60))
+INTERVAL=$((5*60))
+END=$((SECONDS + DURATION))
+
+while [ $SECONDS -lt $END ]; do
+    IDX=$((RANDOM % ${#NODES[@]}))
+    NODE_NAME=${NODES[$IDX]}
+    PID_FILE="/tmp/${NODE_NAME}.pid"
+    if [ -f "$PID_FILE" ]; then
+        PID=$(cat "$PID_FILE")
+        echo "[Chaos] Killing $NODE_NAME (pid $PID)"
+        kill -9 "$PID" 2>/dev/null || true
+        rm -f "$PID_FILE"
+    else
+        echo "[Chaos] $NODE_NAME not running"
+    fi
+    sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Summary
- set replication factor to 3 and implement block replication between nodes
- run background integrity verifier on each node to self-heal corrupted blocks
- describe new replication features in README and progress notes
- add chaos test script that kills a random node every five minutes

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure -VV` *(fails: FuseTestEnvSetup)*

------
https://chatgpt.com/codex/tasks/task_e_6840ea5394b483289e0a8b4481d2b797