### PR TITLE
Document cluster encryption key

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -134,3 +134,17 @@ This project is licensed under the MIT License.
 The `tests/chaos_kill_node.sh` script simulates node failures by randomly killing
 one storage node every five minutes for two hours. Use this after launching the
 metaserver and nodes to evaluate replication healing.
+
+## Security
+SimpliDFS relies on a cluster-wide encryption key. Set the
+`SIMPLIDFS_CLUSTER_KEY` environment variable on every node before starting the
+metaserver or storage nodes to ensure they share the same key. The value must be
+a 64-character hex string (32 bytes). Example:
+
+```sh
+export SIMPLIDFS_CLUSTER_KEY=$(openssl rand -hex 32)
+```
+
+If this variable is missing or malformed, each process generates a new random
+key, preventing other nodes from decrypting its data. See
+[SECURITY.md](SECURITY.md) for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security
+
+## Cluster Encryption Key
+
+SimpliDFS secures data using an AES-256-GCM key shared across the cluster. The
+key is loaded from the `SIMPLIDFS_CLUSTER_KEY` environment variable.
+
+### Key Format
+
+`SIMPLIDFS_CLUSTER_KEY` must be a 64-character hexadecimal string (32 bytes).
+You can create a suitable value with:
+
+```sh
+openssl rand -hex 32
+```
+
+### Fallback Behavior
+
+If the environment variable is unset or does not contain a valid hex string,
+SimpliDFS generates a random key when the process starts. This key exists only in
+memory, so other nodes cannot decrypt data encrypted with it.
+
+Set the environment variable consistently on every node before launching the
+metaserver or storage nodes to ensure they can access shared encrypted data.


### PR DESCRIPTION
## Summary
- add SECURITY.md detailing SIMPLIDFS_CLUSTER_KEY usage
- describe key setup and fallback in README

## Testing
- `cmake -B build -S .`
- `cmake --build build -j$(nproc)`
- `cd build && ctest --output-on-failure -VV` *(fails: FuseTestEnvSetup)*

------
https://chatgpt.com/codex/tasks/task_e_6840f325ffb88328b75cedc3132b6493