### PR TITLE
Add hot cache snapshot delta policy

### DIFF
--- a/include/utilities/message.h
+++ b/include/utilities/message.h
@@ -67,7 +67,9 @@ enum class MessageType{
     RaftRequestVote,
     RaftRequestVoteResponse,
     RaftAppendEntries,
-    RaftAppendEntriesResponse
+    RaftAppendEntriesResponse,
+    /// Snapshot delta from edge node during hot-cache mode
+    SnapshotDelta
 };
 
 /**


### PR DESCRIPTION
## Summary
- add new `SnapshotDelta` message type
- implement hot cache logic in `Node` to record snapshot deltas when the heartbeat fails
- send recorded deltas once backhaul link is restored

## Testing
- `cmake ..`
- `cmake --build . -j $(nproc)`
- `ctest --output-on-failure -VV` *(fails: FuseTestEnvSetup)*

------
https://chatgpt.com/codex/tasks/task_e_6841e8f041408328892058f16dced9a8