### PR TITLE
Add AGENTS.md instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENT Instructions
+
+## Scope
+These guidelines apply to the entire repository.
+
+## Coding Style
+- Follow existing formatting for C++ and shell scripts.
+- Document public functions using Doxygen style comments.
+
+## Commit Messages
+- Use clear, concise messages in the present tense.
+
+## Testing
+Run the unit tests with CMake/CTest:
+```bash
+mkdir -p build && cd build
+cmake ..
+make -j$(nproc)
+ctest --output-on-failure -VV -E FuseTestEnv
+```
+The `-E FuseTestEnv` filter excludes the FUSE integration setup which requires root privileges.


### PR DESCRIPTION
## Summary
- document repo-wide guidelines in `AGENTS.md`

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure -VV -E FuseTestEnv`

------
https://chatgpt.com/codex/tasks/task_e_6842d8d757308328b61caf6ed393e514