### PR TITLE
Implement NodeHealthCache for cluster nodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,8 @@ message(STATUS "_GLIBCXX_USE_CXX11_ABI (Compile Definition Check): $<COMPILE_DEF
 # Define the SimpliDFS_MetaServerLib library
 add_library(SimpliDFS_MetaServerLib
     src/metaserver/metaserver.cpp
-    src/metaserver/node_health_tracker.cpp)
+    src/metaserver/node_health_tracker.cpp
+    src/cluster/NodeHealthCache.cpp)
 target_include_directories(SimpliDFS_MetaServerLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(SimpliDFS_MetaServerLib
     PRIVATE # Should be PUBLIC if SimpliDFS_Utils headers are needed by users of SimpliDFS_MetaServerLib,

--- a/include/cluster/NodeHealthCache.h
+++ b/include/cluster/NodeHealthCache.h
@@ -1,0 +1,61 @@
+#pragma once
+#include <unordered_map>
+#include <vector>
+#include <string>
+#include <chrono>
+
+/**
+ * @file NodeHealthCache.h
+ * @brief Caches recent node health results for placement decisions.
+ */
+
+using NodeID = std::string;
+using SteadyClock = std::chrono::steady_clock;
+
+/**
+ * @brief Represents the current observed state of a node.
+ */
+enum class NodeState { HEALTHY, SUSPECT, DEAD };
+
+/**
+ * @brief Tracks recent communication successes and failures with nodes.
+ *
+ * The cache promotes nodes from SUSPECT to DEAD when failures persist
+ * beyond a timeout and eventually forgets about dead nodes so they can
+ * be retried later.
+ */
+class NodeHealthCache {
+public:
+    /**
+     * @brief Get the current state of a node.
+     * @param id Node identifier.
+     * @return The node's state.
+     */
+    NodeState state(const NodeID &id) const;
+
+    /**
+     * @brief Record a successful communication with a node.
+     * @param id Node identifier.
+     */
+    void recordSuccess(const NodeID &id);
+
+    /**
+     * @brief Record a failed communication with a node.
+     * @param id Node identifier.
+     */
+    void recordFailure(const NodeID &id);
+
+    /**
+     * @brief Return up to @p max node IDs that appear healthy.
+     * @param max Maximum number of nodes to return.
+     */
+    std::vector<NodeID> healthyNodes(size_t max) const;
+
+private:
+    struct Entry { NodeState state; SteadyClock::time_point lastChange; };
+    mutable std::unordered_map<NodeID, Entry> map_;
+    const std::chrono::seconds suspectTimeout{10};
+    const std::chrono::seconds deadTimeout{30};
+    void updateState(const NodeID &id) const;
+};
+

--- a/src/cluster/NodeHealthCache.cpp
+++ b/src/cluster/NodeHealthCache.cpp
@@ -1,0 +1,61 @@
+#include "cluster/NodeHealthCache.h"
+
+void NodeHealthCache::updateState(const NodeID &id) const {
+    auto it = map_.find(id);
+    if (it == map_.end()) return;
+    auto now = SteadyClock::now();
+    Entry &e = const_cast<Entry &>(it->second);
+    if (e.state == NodeState::SUSPECT && now - e.lastChange >= suspectTimeout) {
+        e.state = NodeState::DEAD;
+        e.lastChange = now;
+    } else if (e.state == NodeState::DEAD && now - e.lastChange >= deadTimeout) {
+        map_.erase(it);
+    }
+}
+
+NodeState NodeHealthCache::state(const NodeID &id) const {
+    updateState(id);
+    auto it = map_.find(id);
+    if (it == map_.end()) return NodeState::HEALTHY;
+    return it->second.state;
+}
+
+void NodeHealthCache::recordSuccess(const NodeID &id) {
+    Entry &e = map_[id];
+    e.state = NodeState::HEALTHY;
+    e.lastChange = SteadyClock::now();
+}
+
+void NodeHealthCache::recordFailure(const NodeID &id) {
+    Entry &e = map_[id];
+    if (e.state == NodeState::DEAD) {
+        e.lastChange = SteadyClock::now();
+    } else {
+        e.state = NodeState::SUSPECT;
+        e.lastChange = SteadyClock::now();
+    }
+}
+
+std::vector<NodeID> NodeHealthCache::healthyNodes(size_t max) const {
+    std::vector<NodeID> result;
+    result.reserve(max);
+    auto now = SteadyClock::now();
+    for (auto it = map_.begin(); it != map_.end(); ) {
+        Entry &e = const_cast<Entry &>(it->second);
+        if (e.state == NodeState::SUSPECT && now - e.lastChange >= suspectTimeout) {
+            e.state = NodeState::DEAD;
+            e.lastChange = now;
+        }
+        if (e.state == NodeState::DEAD && now - e.lastChange >= deadTimeout) {
+            it = map_.erase(it);
+            continue;
+        }
+        if (e.state == NodeState::HEALTHY) {
+            result.push_back(it->first);
+            if (result.size() == max) break;
+        }
+        ++it;
+    }
+    return result;
+}
+


### PR DESCRIPTION
## Summary
- create NodeHealthCache with HEALTHY/SUSPECT/DEAD states
- add implementation for recording successes and failures
- expose helper to get healthy nodes
- compile NodeHealthCache with metaserver library

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure -VV -E FuseTestEnv`


------
https://chatgpt.com/codex/tasks/task_e_6842f6036fb883288cbf5750c398b48a