### PR TITLE
Implement health management layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,5 +177,16 @@ add_subdirectory(src/utilities)
 enable_testing()
 add_subdirectory(tests)
 
+# ⭐ NEW CODE
+FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v3.5.2
+)
+FetchContent_MakeAvailable(Catch2)
+add_executable(health_tests tests/test_health.cpp)
+target_link_libraries(health_tests PRIVATE Catch2::Catch2WithMain SimpliDFS_MetaServerLib)
+add_test(NAME health_tests COMMAND health_tests)
+
 # Add benchmark subdirectory
 add_subdirectory(bench)

--- a/include/metaserver/metaserver.h
+++ b/include/metaserver/metaserver.h
@@ -369,6 +369,12 @@ public:
 
     NodeHealthCache& healthCache() { return healthCache_; }
 
+    /// ⭐ NEW CODE
+    /**
+     * @brief Pick up to @p count nodes that are considered alive.
+     */
+    std::vector<std::string> pickLiveNodes(size_t count);
+
     /**
      * @brief Checks if a node with the given identifier is registered.
      * @param nodeIdentifier The unique identifier of the node.

--- a/include/repair/RepairWorker.h
+++ b/include/repair/RepairWorker.h
@@ -3,6 +3,9 @@
 #include <unordered_map>
 #include <string>
 #include <vector>
+#include <chrono>
+#include <thread>
+#include <atomic>
 
 struct InodeEntry {
     std::vector<NodeID> replicas;
@@ -13,13 +16,23 @@ class RepairWorker {
 public:
     RepairWorker(std::unordered_map<std::string, InodeEntry>& table,
                  NodeHealthCache& cache,
-                 size_t replicationFactor = 3)
-        : table_(table), cache_(cache), replicationFactor_(replicationFactor) {}
+                 size_t replicationFactor = 3,
+                 std::chrono::seconds tick = std::chrono::seconds(5))
+        : table_(table), cache_(cache), replicationFactor_(replicationFactor), tick_(tick) {}
 
+    ~RepairWorker();
+
+    void start();
+    void stop();
     void runOnce();
 
 private:
+    void threadFunc();
+
     std::unordered_map<std::string, InodeEntry>& table_;
     NodeHealthCache& cache_;
     size_t replicationFactor_;
+    std::chrono::seconds tick_;
+    std::atomic<bool> running_{false};
+    std::thread worker_;
 };

--- a/src/repair/RepairWorker.cpp
+++ b/src/repair/RepairWorker.cpp
@@ -1,16 +1,39 @@
 #include "repair/RepairWorker.h"
 #include <algorithm>
 
+RepairWorker::~RepairWorker() { stop(); }
+
+void RepairWorker::start() {
+    if (running_) return;
+    running_ = true;
+    worker_ = std::thread(&RepairWorker::threadFunc, this);
+}
+
+void RepairWorker::stop() {
+    if (!running_) return;
+    running_ = false;
+    if (worker_.joinable()) worker_.join();
+}
+
+void RepairWorker::threadFunc() {
+    while (running_) {
+        runOnce();
+        for (std::chrono::seconds s{0}; s < tick_ && running_; s += std::chrono::seconds(1)) {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+    }
+}
+
 void RepairWorker::runOnce() {
-    auto candidates = cache_.healthyNodes(replicationFactor_ * 2);
-    for (auto& kv : table_) {
-        auto& inode = kv.second;
+    auto candidates = cache_.getHealthyNodes();
+    for (auto &kv : table_) {
+        auto &inode = kv.second;
         if (!inode.partial)
             continue;
-        size_t missing = 0;
-        if (inode.replicas.size() < replicationFactor_)
-            missing = replicationFactor_ - inode.replicas.size();
-        for (const auto& n : candidates) {
+        size_t missing = replicationFactor_ > inode.replicas.size()
+                             ? replicationFactor_ - inode.replicas.size()
+                             : 0;
+        for (const auto &n : candidates) {
             if (missing == 0)
                 break;
             if (std::find(inode.replicas.begin(), inode.replicas.end(), n) == inode.replicas.end()) {

--- a/src/simplidfs_ctl.cpp
+++ b/src/simplidfs_ctl.cpp
@@ -7,7 +7,7 @@ extern MetadataManager metadataManager;
 
 static std::string stateToString(NodeState s) {
     switch (s) {
-        case NodeState::HEALTHY: return "HEALTHY";
+        case NodeState::ALIVE: return "ALIVE";
         case NodeState::SUSPECT: return "SUSPECT";
         default: return "DEAD";
     }

--- a/tests/metaserver_tests.cpp
+++ b/tests/metaserver_tests.cpp
@@ -238,16 +238,15 @@ TEST_F(MetadataManagerTest, NodeHealthCacheMarksFailures) {
     int res = metadataManager.addFile("health.txt", nodes, 0644);
     EXPECT_EQ(res, ERR_INSUFFICIENT_REPLICA);
     EXPECT_EQ(metadataManager.getNodeHealthState("A"), NodeState::SUSPECT);
-    EXPECT_EQ(metadataManager.getNodeHealthState("B"), NodeState::HEALTHY);
+    EXPECT_EQ(metadataManager.getNodeHealthState("B"), NodeState::ALIVE);
 
     sb.stop();
     sc.stop();
 }
 
 TEST(NodeHealthCache, FailureEscalation) {
-    NodeHealthCache cache;
+    NodeHealthCache cache(2, 3, std::chrono::seconds(1));
     cache.recordFailure("X");
-    std::this_thread::sleep_for(std::chrono::seconds(30));
     cache.recordFailure("X");
     EXPECT_EQ(cache.state("X"), NodeState::DEAD);
 }

--- a/tests/repair_worker_tests.cpp
+++ b/tests/repair_worker_tests.cpp
@@ -2,7 +2,7 @@
 #include "repair/RepairWorker.h"
 
 TEST(RepairWorker, HealsPartial) {
-    NodeHealthCache cache(std::chrono::seconds(1), std::chrono::seconds(5));
+    NodeHealthCache cache(2,3,std::chrono::seconds(1));
     cache.recordSuccess("nodeB");
     cache.recordSuccess("nodeC");
     std::unordered_map<std::string, InodeEntry> table;

--- a/tests/test_health.cpp
+++ b/tests/test_health.cpp
@@ -1,0 +1,49 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>
+#include "cluster/NodeHealthCache.h"
+#include "repair/RepairWorker.h"
+#include "metaserver/metaserver.h"
+#include <algorithm>
+
+TEST_CASE("Node transitions based on successes and failures") {
+    NodeHealthCache cache(2, 3, std::chrono::seconds(1));
+    const std::string id = "N";
+    cache.recordFailure(id);
+    REQUIRE(cache.state(id) == NodeState::SUSPECT);
+    cache.recordFailure(id);
+    REQUIRE(cache.state(id) == NodeState::DEAD);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    cache.recordSuccess(id);
+    cache.recordSuccess(id);
+    cache.recordSuccess(id);
+    REQUIRE(cache.state(id) == NodeState::ALIVE);
+}
+
+TEST_CASE("pickLiveNodes filters dead nodes") {
+    MetadataManager mm;
+    mm.registerNode("A","127.0.0.1",1001);
+    mm.registerNode("B","127.0.0.1",1002);
+    mm.healthCache().recordFailure("B");
+    mm.healthCache().recordFailure("B");
+    auto nodes = mm.pickLiveNodes(2);
+    REQUIRE(std::find(nodes.begin(), nodes.end(), "B") == nodes.end());
+}
+
+TEST_CASE("RepairWorker heals partial replicas") {
+    NodeHealthCache cache(2,3,std::chrono::seconds(1));
+    cache.recordSuccess("nodeB");
+    cache.recordSuccess("nodeC");
+    std::unordered_map<std::string, InodeEntry> table;
+    table["file"].replicas = {"nodeA"};
+    table["file"].partial = true;
+    RepairWorker worker(table, cache, 3, std::chrono::seconds(1));
+    worker.start();
+    auto start = SteadyClock::now();
+    while (SteadyClock::now() - start < std::chrono::seconds(30)) {
+        if (!table["file"].partial) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    worker.stop();
+    REQUIRE_FALSE(table["file"].partial);
+    REQUIRE(table["file"].replicas.size() >= 3);
+}


### PR DESCRIPTION
## Summary
- add thread-safe `NodeHealthCache` with success/failure thresholds
- implement background `RepairWorker`
- update metadata manager to use the cache for node selection
- provide catch2 tests for health tracking and repair logic

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure -VV -E FuseTestEnv`

------
https://chatgpt.com/codex/tasks/task_e_684312a4440c83289d283675c80724f6