### PR TITLE
Add Raft chaos test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Unit tests for the core networking library functionalities (`Networking::Client`, `Networking::Server`).
 - Fuzz testing suite integrated with libFuzzer (build with `-DBUILD_FUZZING=ON`).
+- Chaos test validating leader death recovery in the Raft implementation.
 
 ### Changed
 - Integrated an internal networking library (providing `Networking::Client` and `Networking::Server` classes) directly into the project source (`src/client.cpp`, `src/client.h`, `src/server.cpp`, `src/server.h`).

--- a/include/utilities/raft.h
+++ b/include/utilities/raft.h
@@ -33,6 +33,13 @@ public:
     bool isLeader() const;
     std::string getLeader() const;
 
+    /**
+     * @brief Retrieve the current log entries for testing.
+     *
+     * @return A copy of the log vector.
+     */
+    std::vector<RaftLogEntry> getLog() const;
+
     void handleMessage(const Message& msg, const std::string& from);
     void appendCommand(const std::string& command);
 

--- a/src/utilities/raft.cpp
+++ b/src/utilities/raft.cpp
@@ -221,4 +221,9 @@ void RaftNode::appendCommand(const std::string& command) {
     log.push_back({currentTerm, command});
 }
 
+std::vector<RaftLogEntry> RaftNode::getLog() const {
+    std::lock_guard<std::mutex> lk(mtx);
+    return log;
+}
+
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(SimpliDFSTests
     chunk_store_tests.cpp
     integration_tests.cpp # Added new integration tests file
     raft_tests.cpp
+    raft_chaos_tests.cpp
     repair_worker_tests.cpp
     # Removed direct compilation of utility sources:
     # ../../src/utilities/filesystem.cpp

--- a/tests/raft_chaos_tests.cpp
+++ b/tests/raft_chaos_tests.cpp
@@ -1,0 +1,87 @@
+#include "gtest/gtest.h"
+#include "utilities/raft.h"
+#include <unordered_map>
+#include <random>
+#include <thread>
+#include <chrono>
+
+class InMemoryNetworkChaos {
+public:
+    std::unordered_map<std::string, RaftNode*> nodes;
+    void send(const std::string& from, const std::string& to, const Message& m) {
+        auto it = nodes.find(to);
+        if (it != nodes.end()) {
+            Message copy = m;
+            copy._NodeAddress = from;
+            it->second->handleMessage(copy, from);
+        }
+    }
+};
+
+TEST(RaftChaos, KillLeaderNoDataLoss) {
+    InMemoryNetworkChaos net;
+    std::vector<std::string> ids = {"A","B","C"};
+    std::unordered_map<std::string, std::unique_ptr<RaftNode>> nodes;
+    for (const auto& id : ids) {
+        std::vector<std::string> peers;
+        for (const auto& other : ids) if (other != id) peers.push_back(other);
+        nodes[id] = std::make_unique<RaftNode>(id, peers,
+            [&](const std::string& peer, const Message& m){ net.send(id, peer, m); });
+        net.nodes[id] = nodes[id].get();
+        nodes[id]->start();
+    }
+
+    // Wait for leader election
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    std::string leader;
+    for (const auto& id : ids) {
+        if (nodes[id]->isLeader()) {
+            leader = id;
+            break;
+        }
+    }
+    ASSERT_FALSE(leader.empty());
+
+    nodes[leader]->appendCommand("cmd1");
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    // Kill the leader
+    nodes[leader]->stop();
+    net.nodes.erase(leader);
+
+    // Wait for re-election
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    std::string newLeader;
+    int leaderCount = 0;
+    for (const auto& id : ids) {
+        if (id == leader) continue;
+        if (nodes[id]->isLeader()) {
+            newLeader = id;
+            leaderCount++;
+        }
+    }
+    EXPECT_EQ(leaderCount, 1);
+    ASSERT_FALSE(newLeader.empty());
+
+    nodes[newLeader]->appendCommand("cmd2");
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    // Restart old leader to verify log replication
+    nodes[leader]->start();
+    net.nodes[leader] = nodes[leader].get();
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    auto expected = nodes[newLeader]->getLog();
+    for (const auto& id : ids) {
+        auto log = nodes[id]->getLog();
+        ASSERT_EQ(log.size(), expected.size());
+        for (size_t i = 0; i < log.size(); ++i) {
+            EXPECT_EQ(log[i].command, expected[i].command);
+        }
+    }
+
+    for (auto& p : nodes) p.second->stop();
+}
+


### PR DESCRIPTION
## Summary
- expose log from `RaftNode`
- create `RaftChaos` test that kills the leader and checks replication
- register the new test in CMake
- document the chaos test in the changelog

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure -VV -E FuseTestEnv`

------
https://chatgpt.com/codex/tasks/task_e_68439b9934288328aa5975e9ce6e7797