### PR TITLE
I've made some improvements to the FuseConcurrencyTest environment an…

### DIFF
--- a/tests/run_fuse_concurrency_test_wrapper.sh
+++ b/tests/run_fuse_concurrency_test_wrapper.sh
@@ -195,14 +195,14 @@ sleep 5 # Give it time to mount
 
 # Check FUSE Adapter and Mount
 if ! ps -p ${FUSE_ADAPTER_PID} > /dev/null; then
-   echo "SKIP: FUSE adapter process ${FUSE_ADAPTER_PID} failed to start."
-   cleanup_and_exit 0
+   echo "ERROR: FUSE adapter process ${FUSE_ADAPTER_PID} failed to start."
+   cleanup_and_exit 1
 fi
 echo "INFO: FUSE Adapter PID: ${FUSE_ADAPTER_PID}"
 
 if ! mount | grep -q ${MOUNT_POINT}; then
-    echo "SKIP: Mount check: ${MOUNT_POINT} is not mounted."
-    cleanup_and_exit 0
+    echo "ERROR: Mount check: ${MOUNT_POINT} is not mounted."
+    cleanup_and_exit 1
 fi
 echo "INFO: FUSE successfully mounted at ${MOUNT_POINT}."
 


### PR DESCRIPTION
…d its error reporting.

Here's what I did:

1.  I modified `tests/run_fuse_concurrency_test_wrapper.sh`:
    *   I made sure the script exits with a non-zero status code if the FUSE adapter fails to start or if the mount point isn't set up correctly. Before, it would exit with 0, which hid these important setup problems from CTest.
    *   I changed "SKIP" messages to "ERROR" for these situations to better show how serious they are.

2.  I found and fixed a missing dependency:
    *   The FUSE adapter wasn't starting because it couldn't find the `fusermount3` executable.
    *   I resolved this by ensuring the `fuse3` package is installed in the test environment.

With these adjustments, the `FuseConcurrencyTest` environment is now set up correctly, and the FUSE adapter starts and mounts the filesystem as expected. The test now progresses further but currently fails within the C++ test logic with the error "Main: Failed to preallocate test file." This tells us the environment issues are fixed, and we can now focus on debugging the C++ implementation of the test.

Here's how I approached this:
- I explored your codebase to understand the build and test procedures.
- I built the project.
- I ran the FuseConcurrencyTest and noticed it was incorrectly passing because of an error handling issue in the wrapper script.
- I modified the wrapper script to ensure errors are correctly reported.
- I ran the test again and diagnosed a missing `fusermount3` from the logs.
- I installed the `fuse3` dependency.
- I ran the test once more, and now the FUSE adapter starts, but the test fails within the C++ code.