### PR TITLE
Fix FUSE readdir delimiter

### DIFF
--- a/src/utilities/fuse_adapter.cpp
+++ b/src/utilities/fuse_adapter.cpp
@@ -460,7 +460,7 @@ int simpli_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t of
 
         std::istringstream name_stream(res_msg._Data);
         std::string name_token;
-        while(std::getline(name_stream, name_token, ' ')) { // Corrected: char literal ' '
+        while(std::getline(name_stream, name_token, '\0')) {
             if (!name_token.empty()) {
                 filler(buf, name_token.c_str(), NULL, 0, (enum fuse_fill_dir_flags)0);
             }


### PR DESCRIPTION
## Summary
- use correct `\0` delimiter when parsing `Readdir` responses in the fuse adapter

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure -VV -E FuseTestEnv`


------
https://chatgpt.com/codex/tasks/task_e_684f426b75488328911129e2ca9b289b