### PR TITLE
Improve FUSE concurrency test stability

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(SimpliDFSTests
     metrics_registry_tests.cpp
     merkle_tree_tests.cpp
     open_file_with_retry_tests.cpp
+    seekp_with_retry_tests.cpp
     node_io_tests.cpp
     # Removed direct compilation of utility sources:
     # ../../src/utilities/filesystem.cpp

--- a/tests/fuse_concurrency_test_utils.hpp
+++ b/tests/fuse_concurrency_test_utils.hpp
@@ -193,4 +193,31 @@ inline bool openFileWithRetry(const std::string& path, std::ifstream& stream,
     return false;
 }
 
+/**
+ * @brief Seek the put pointer of an fstream with retry logic.
+ *
+ * Certain FUSE implementations occasionally return transient errors when
+ * repositioning a stream immediately after a write. This helper retries the
+ * seek several times, clearing error flags between attempts.
+ *
+ * @param stream    fstream whose put pointer should be moved.
+ * @param offset    Absolute offset from the beginning of the file.
+ * @param retries   Number of additional attempts after the first try.
+ * @param delay_ms  Delay in milliseconds between attempts.
+ * @return true if the seek succeeds, false otherwise.
+ */
+inline bool seekpWithRetry(std::fstream& stream, std::streamoff offset,
+                           int retries = 2, int delay_ms = 50) {
+    for (int attempt = 0; attempt <= retries; ++attempt) {
+        stream.clear();
+        stream.seekp(offset, std::ios::beg);
+        if (!stream.fail()) {
+            return true;
+        }
+        stream.clear();
+        std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+    }
+    return false;
+}
+
 #endif // SIMPLIDFS_FUSE_CONCURRENCY_TEST_UTILS_HPP

--- a/tests/fuse_concurrency_tests.cpp
+++ b/tests/fuse_concurrency_tests.cpp
@@ -273,12 +273,12 @@ void writer_thread_func(int thread_id) {
     // This is key to the "random write" nature of the test, ensuring threads
     // write to their designated, non-overlapping areas, even if the file was
     // pre-allocated.
-    outfile.seekp(offset);
+    bool seek_ok = seekpWithRetry(outfile, offset);
 
-    // Log success or failure of seekp, including stream state and current
+    // Log success or failure of seek, including stream state and current
     // position. This helps debug issues if seek operations are not behaving as
     // expected.
-    if (outfile.fail()) {
+    if (!seek_ok) {
       std::cerr << "[FUSE CONCURRENCY LOG " << getFuseTestTimestamp()
                 << " TID: " << std::this_thread::get_id() << "] Thread "
                 << thread_id << ": Seekp to " << offset

--- a/tests/seekp_with_retry_tests.cpp
+++ b/tests/seekp_with_retry_tests.cpp
@@ -1,0 +1,29 @@
+#include <gtest/gtest.h>
+#include "fuse_concurrency_test_utils.hpp"
+#include <fstream>
+#include <cstdio>
+
+/**
+ * @brief Ensure seekpWithRetry positions a valid stream.
+ */
+TEST(SeekpWithRetry, WorksForValidOffset) {
+    const std::string path = "seek_retry_valid.txt";
+    {
+        std::ofstream out(path, std::ios::binary);
+        out << std::string(20, 'a');
+    }
+    std::fstream fs(path, std::ios::in | std::ios::out | std::ios::binary);
+    ASSERT_TRUE(fs.is_open());
+    EXPECT_TRUE(seekpWithRetry(fs, 5));
+    EXPECT_EQ(static_cast<std::streamoff>(fs.tellp()), 5);
+    fs.close();
+    std::remove(path.c_str());
+}
+
+/**
+ * @brief Ensure seekpWithRetry returns false for an unopened stream.
+ */
+TEST(SeekpWithRetry, FailsForClosedStream) {
+    std::fstream fs; // not opened
+    EXPECT_FALSE(seekpWithRetry(fs, 10, 1, 10));
+}


### PR DESCRIPTION
## Summary
- add `seekpWithRetry` helper to retry seek operations
- use new helper in FUSE concurrency writer threads
- add unit tests for the helper

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure -VV`

------
https://chatgpt.com/codex/tasks/task_e_68547d895500832895944c8b78ba9874