### PR TITLE
Switch hashing to BLAKE3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,9 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(yaml-cpp)
 
+# Local third-party libraries
+add_subdirectory(third_party/blake3)
+
 message(STATUS "CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}")
 message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 message(STATUS "_GLIBCXX_USE_CXX11_ABI (Compile Definition Check): $<COMPILE_DEFINITIONS:_GLIBCXX_USE_CXX11_ABI>")
@@ -130,7 +133,7 @@ add_library(SimpliDFS_MetaServerLib
     src/repair/ReplicaVerifier.cpp)
 target_include_directories(SimpliDFS_MetaServerLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(SimpliDFS_MetaServerLib
-    PRIVATE # Should be PUBLIC if SimpliDFS_Utils headers are needed by users of SimpliDFS_MetaServerLib,
+    PUBLIC # SimpliDFS_Utils headers are needed by users of SimpliDFS_MetaServerLib,
             # or INTERFACE if SimpliDFS_Utils is header-only and its headers are included by SimpliDFS_MetaServerLib headers.
             # For now, PRIVATE if SimpliDFS_Utils is mostly .cpp linked into MetaServerLib.
             # If metaserver.h includes headers from SimpliDFS_Utils that then are needed by things linking to MetaServerLib,

--- a/docs/hash_layer.md
+++ b/docs/hash_layer.md
@@ -1,8 +1,8 @@
-# BlockIO SHA-256 Hashing Layer
+#BlockIO Hashing Layer
 
-## 1. Overview of SHA-256 Hashing
+## 1. Overview
 
-The `BlockIO` class has been enhanced to support SHA-256 hashing of all data ingested through its `ingest()` method. This feature allows users to obtain a cryptographic hash of the concatenated data, which can be used to verify data integrity.
+The `BlockIO` class computes a cryptographic digest of all data ingested through its `ingest()` method. The algorithm is selected via the `HashAlgorithm` enum and defaults to **BLAKE3**, but `SHA256` remains available for compatibility.
 
 The new API for accessing this functionality is:
 
@@ -10,56 +10,59 @@ The new API for accessing this functionality is:
 DigestResult BlockIO::finalize_hashed();
 ```
 
-This method finalizes the data ingestion process and computes the SHA-256 hash. It returns a `DigestResult` struct, defined as follows:
+    This method finalizes the data ingestion process and computes the BLAKE3
+        hash.It returns a `DigestResult` struct,
+    defined as follows :
 
 ```cpp
 #include <array>
+#include <cstddef>  // For std::byte
+#include <sodium.h> // For BLAKE3_OUT_LEN
 #include <vector>
-#include <cstddef> // For std::byte
-#include <sodium.h>  // For crypto_hash_sha256_BYTES
 
-struct DigestResult {
-    std::array<uint8_t, crypto_hash_sha256_BYTES> digest; // SHA-256 hash (32 bytes)
-    std::vector<std::byte> raw;                           // Concatenated raw data
+    struct DigestResult {
+  std::array<uint8_t, BLAKE3_OUT_LEN> digest; // BLAKE3 hash (32 bytes)
+  std::vector<std::byte> raw;                 // Concatenated raw data
 };
 ```
 
--   `digest`: An array of 32 `uint8_t` values representing the computed SHA-256 digest.
+-   `digest`: An array of 32 `uint8_t` values representing the computed BLAKE3 digest.
 -   `raw`: A vector of `std::byte` containing all the data ingested, in its original order.
 
 Once `finalize_hashed()` is called, the `BlockIO` instance is considered "finalized." Further calls to `ingest()` or `finalize_hashed()` on the same instance will result in a `std::logic_error`.
 
 ## 2. Impact of Chunk Size
 
-The SHA-256 algorithm, as implemented using libsodium (`crypto_hash_sha256_update`), processes data incrementally. This means that data is fed into the hashing function chunk by chunk.
+The BLAKE3 algorithm,, processes data incrementally. This means that data is fed into the hashing function chunk by chunk.
 
 **Key Points:**
 
-*   **Total Data Dominates:** The performance of the hashing computation itself is primarily determined by the *total volume* of data processed, not by the size or number of individual chunks passed to the `ingest()` method. Whether you ingest 1 MiB of data in a single call or in 1024 calls of 1 KiB each, the cryptographic operations performed by libsodium will be largely the same.
-*   **Function Call Overhead:** While the cryptographic workload remains constant for a given total data size, using extremely small chunks in very frequent calls to `ingest()` can introduce minor overhead. This overhead comes from the repeated function call invocations and the internal state updates within the `BlockIO` class and libsodium's hashing context. However, for typical use cases with reasonably sized chunks (e.g., kilobytes or megabytes), this overhead is generally negligible compared to the time spent on the actual hash calculations.
-*   **Buffer Management:** The `BlockIO` class uses an internal `std::vector<std::byte>` to buffer the ingested data. The efficiency of this buffer's management (reallocations, copies) can be influenced by the chunking strategy. If a user frequently ingests very small, unpredictable amounts of data, this might lead to more reallocations of the internal buffer. The hashing update via `crypto_hash_sha256_update` itself is efficient as it operates on the provided data pointers and sizes directly, without necessarily requiring further copies for the hashing context itself.
+*   **Total Data Dominates:** The performance of the hashing computation itself is primarily determined by the *total volume* of data processed, not by the size or number of individual chunks passed to the `ingest()` method. Whether you ingest 1 MiB of data in a single call or in 1024 calls of 1 KiB each, the cryptographic operations performed by the hash algorithm will be largely the same.
+*   **Function Call Overhead:** While the cryptographic workload remains constant for a given total data size, using extremely small chunks in very frequent calls to `ingest()` can introduce minor overhead. This overhead comes from the repeated function call invocations and the internal state updates within the `BlockIO` class and the hashing context. However, for typical use cases with reasonably sized chunks (e.g., kilobytes or megabytes), this overhead is generally negligible compared to the time spent on the actual hash calculations.
+*   **Buffer Management:** The `BlockIO` class uses an internal `std::vector<std::byte>` to buffer the ingested data. The efficiency of this buffer's management (reallocations, copies) can be influenced by the chunking strategy. If a user frequently ingests very small, unpredictable amounts of data, this might lead to more reallocations of the internal buffer. The hashing update via `blake3_hasher_update` itself is efficient as it operates on the provided data pointers and sizes directly, without necessarily requiring further copies for the hashing context itself.
 
 In summary, while the hashing algorithm is efficient with incremental updates, users should still employ a sensible chunking strategy for `ingest()` calls to optimize overall performance, primarily considering the overhead of buffer management within `BlockIO` and the function call overhead itself if chunks are excessively small and numerous.
 
 ## 3. "Invariant Hash First" Principle
 
-A core design principle for the hashing layer in `BlockIO` is **"Invariant Hash First."** This means that the SHA-256 hash is always computed on the data in its original, raw, and unaltered form, exactly as it was provided to the `ingest()` method.
+A core design principle for the hashing layer in `BlockIO` is **"Invariant Hash First."** This means that the BLAKE3 hash is always computed on the data in its original, raw, and unaltered form, exactly as it was provided to the `ingest()` method.
 
 **Importance:**
 
-If `BlockIO` is extended in the future to include additional processing stages—such as data compression or encryption—these transformations would occur *after* the data has been processed by the SHA-256 hashing mechanism (or, more precisely, the hash is calculated on the data *before* it would be passed to such stages).
+If `BlockIO` is extended in the future to include additional processing stages—such as data compression or encryption—these transformations would occur *after* the data has been processed by the BLAKE3 hashing mechanism (or, more precisely, the hash is calculated on the data *before* it would be passed to such stages).
 
-This ensures that the generated SHA-256 digest always corresponds to the **original plaintext data**. This is crucial for several reasons:
+This ensures that the generated BLAKE3 digest always corresponds to the **original plaintext data**. This is crucial for several reasons:
 
 *   **Integrity Verification:** Users can reliably use the hash to verify the integrity of the initial data source, regardless of any subsequent transformations applied for storage or transmission.
 *   **Decoupling:** It decouples the integrity check from other data processing operations. You can verify the original data without needing to reverse compression or decryption first.
 *   **Clarity:** It provides a clear and unambiguous definition of what the hash represents.
 
-This principle guarantees that the `BlockIO`'s SHA-256 hash serves as a stable and trustworthy fingerprint of the original input.
+This principle guarantees that the `BlockIO`'s BLAKE3 hash serves as a stable and trustworthy fingerprint of the original input.
 
 ## 4. Content Identifiers (CIDs)
 
-While raw SHA-256 digests provide excellent data integrity verification, Content Identifiers (CIDs) offer a standardized and more descriptive way to reference content-addressed data.
+While raw BLAKE3 digests provide excellent data integrity verification,
+    Content Identifiers(CIDs) offer a standardized and more descriptive way to reference content-addressed data.
 
 ### What are CIDs?
 
@@ -74,16 +77,16 @@ The CIDs implemented and used by our system follow a specific structure:
 *   **Multicodec Prefixes**: The core of a CID's self-describing nature comes from multicodec prefixes:
     *   `0x01`: Specifies CIDv1.
     *   `0x70`: Multicodec for `dag-pb`, indicating the content is likely an IPLD DAG Protocol Buffers node. While our raw data might not always be `dag-pb`, this is a common default codec used for general data when not otherwise specified in many IPFS contexts.
-    *   `0x12`: Multicodec for `sha2-256`, indicating the hash algorithm used.
-    *   `0x20`: Specifies the length of the hash digest in bytes (32 bytes for SHA-256).
+    *   `0x1e`: Multicodec for `blake3`, indicating the hash algorithm used.
+    *   `0x20`: Specifies the length of the hash digest in bytes (32 bytes for BLAKE3).
 
-A complete CID string thus wraps the raw SHA-256 hash with these defined prefixes, then encodes the entire byte sequence into Base32. For example, `bafy...`.
+A complete CID string thus wraps the raw BLAKE3 hash with these defined prefixes, then encodes the entire byte sequence into Base32. For example, `bafy...`.
 
 ### Rationale for Adoption
 
 Adopting CIDs provides several key benefits over using raw hash digests:
 
-*   **Self-Describing Hashes**: CIDs embed the hash algorithm (SHA-256), its length, the CID version, and the data codec. This makes identifiers future-proof (e.g., allowing for new hash algorithms) and reduces ambiguity when encountering an identifier.
+*   **Self-Describing Hashes**: CIDs embed the hash algorithm (BLAKE3), its length, the CID version, and the data codec. This makes identifiers future-proof (e.g., allowing for new hash algorithms) and reduces ambiguity when encountering an identifier.
 *   **Interoperability**: CIDs are the standard for addressing data in systems like IPFS, Filecoin, and other decentralized storage networks. Using CIDs improves our ability to interoperate with these ecosystems and leverage associated tools and services.
 *   **Standardization**: It aligns our system with a well-defined and widely adopted industry standard for content addressing, moving beyond proprietary or context-specific hash representations.
 *   **Uniqueness & Verifiability**: CIDs retain all the benefits of cryptographic hashes. They are still derived from the content's hash, ensuring data integrity, uniqueness, and verifiability.
@@ -94,15 +97,15 @@ Reflecting this enhancement, the `DigestResult` struct returned by `BlockIO::fin
 
 ```cpp
 #include <array>
+#include <cstddef>  // For std::byte
+#include <sodium.h> // For BLAKE3_OUT_LEN
+#include <string>   // For std::string
 #include <vector>
-#include <string>  // For std::string
-#include <cstddef> // For std::byte
-#include <sodium.h>  // For crypto_hash_sha256_BYTES
 
 struct DigestResult {
-    std::array<uint8_t, crypto_hash_sha256_BYTES> digest; // SHA-256 hash
-    std::string cid;                                      // Content Identifier (CID) string
-    std::vector<std::byte> raw;                           // Concatenated raw data
+  std::array<uint8_t, BLAKE3_OUT_LEN> digest; // BLAKE3 hash
+  std::string cid;                            // Content Identifier (CID) string
+  std::vector<std::byte> raw;                 // Concatenated raw data
 };
 ```
 The `cid` field now provides a ready-to-use, standard identifier for the hashed content, alongside the raw digest and data.

--- a/include/utilities/cid_utils.hpp
+++ b/include/utilities/cid_utils.hpp
@@ -1,42 +1,43 @@
 #ifndef CID_UTILS_HPP
 #define CID_UTILS_HPP
 
+#include <array>
+#include <cstdint>   // For uint8_t
+#include <stdexcept> // For std::runtime_error
 #include <string>
 #include <vector>
-#include <array>
-#include <stdexcept> // For std::runtime_error
-#include <cstdint>   // For uint8_t
 
-// Assuming crypto_hash_sha256_BYTES is defined elsewhere,
-// e.g., in a sodiumoxide header or a custom crypto header.
-// For now, let's define it if it's not available.
-#ifndef crypto_hash_sha256_BYTES
-#define crypto_hash_sha256_BYTES 32
-#endif
+#include "blake3.h"
+#include "digest.hpp"
+
+// Digest size is fixed to 32 bytes for supported algorithms
 
 namespace sgns::utils {
 
-extern const std::vector<uint8_t> CID_PREFIX;
+extern const std::vector<uint8_t> CID_PREFIX_SHA256;
+extern const std::vector<uint8_t> CID_PREFIX_BLAKE3;
 
 /**
- * @brief Converts a SHA-256 digest to a CIDv1 string.
- * @param digest The SHA-256 digest.
+ * @brief Converts a digest to a CIDv1 string.
+ * @param digest The hash digest.
  * @return The CIDv1 string.
  */
-std::string digest_to_cid(const std::array<uint8_t, crypto_hash_sha256_BYTES>& digest);
+std::string digest_to_cid(const sgns::utils::DigestArray &digest,
+                          HashAlgorithm algo = HashAlgorithm::BLAKE3);
 
 /**
- * @brief Converts a CIDv1 string to a SHA-256 digest.
+ * @brief Converts a CIDv1 string to its digest.
  * @param cid The CIDv1 string.
- * @return The SHA-256 digest.
+ * @return The extracted digest.
  * @throws std::runtime_error if the CID is invalid.
  */
-std::array<uint8_t, crypto_hash_sha256_BYTES> cid_to_digest(const std::string& cid);
+DigestArray cid_to_digest(const std::string &cid,
+                          HashAlgorithm *algo_out = nullptr);
 
 /**
  * @brief Convert a CIDv1 string to its raw byte representation.
  */
-std::vector<uint8_t> cid_to_bytes(const std::string& cid);
+std::vector<uint8_t> cid_to_bytes(const std::string &cid);
 
 } // namespace sgns::utils
 

--- a/include/utilities/digest.hpp
+++ b/include/utilities/digest.hpp
@@ -1,0 +1,19 @@
+#ifndef SIMPLIDFS_DIGEST_HPP
+#define SIMPLIDFS_DIGEST_HPP
+
+#include <array>
+#include <cstddef>
+
+namespace sgns::utils {
+
+/// Supported hashing algorithms.
+enum class HashAlgorithm { SHA256, BLAKE3 };
+
+/// Digest size for supported algorithms (32 bytes).
+inline constexpr size_t DIGEST_SIZE = 32;
+
+using DigestArray = std::array<uint8_t, DIGEST_SIZE>;
+
+} // namespace sgns::utils
+
+#endif // SIMPLIDFS_DIGEST_HPP

--- a/include/utilities/fips.h
+++ b/include/utilities/fips.h
@@ -3,7 +3,7 @@
 /**
  * @brief Perform a basic FIPS self test.
  *
- * The test verifies libsodium's SHA-256 implementation by hashing a known
+ * The test verifies the bundled BLAKE3 implementation by hashing a known
  * string and comparing the result to a hard coded value.
  *
  * @return true if the digest matches, otherwise false.

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -30,6 +30,7 @@ target_include_directories(SimpliDFS_Utils
         ${cppcodec_SOURCE_DIR} # For cppcodec
         ${SODIUM_INCLUDE_DIRS} # For libsodium
         ${OPENSSL_INCLUDE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/blake3
 )
 
 # Add ZSTD include directories for SimpliDFS_Utils
@@ -46,6 +47,7 @@ endif()
 target_link_libraries(SimpliDFS_Utils
     PUBLIC
         cppcodec
+        blake3
         ${SODIUM_LIBRARIES}
         OpenSSL::SSL
         OpenSSL::Crypto

--- a/src/utilities/cid_utils.cpp
+++ b/src/utilities/cid_utils.cpp
@@ -1,70 +1,97 @@
 #include "utilities/cid_utils.hpp"
-#include <vector>
-#include <stdexcept> // For std::runtime_error
+#include "blake3.h"
 #include "cppcodec/base32_rfc4648.hpp" // For Base32 encoding/decoding
+#include "utilities/digest.hpp"
+#include <stdexcept> // For std::runtime_error
+#include <vector>
 
 namespace sgns::utils {
 
 // CIDv1 (0x01)
 // multicodec for DAG-PB (0x70)
-// multicodec for SHA2-256 (0x12)
+// multicodec for SHA2-256 (0x12) or BLAKE3 (0x1e)
 // length of hash (0x20)
-const std::vector<uint8_t> CID_PREFIX = {0x01, 0x70, 0x12, 0x20};
+const std::vector<uint8_t> CID_PREFIX_SHA256 = {0x01, 0x70, 0x12, 0x20};
+const std::vector<uint8_t> CID_PREFIX_BLAKE3 = {0x01, 0x70, 0x1e, 0x20};
 
-std::string digest_to_cid(const std::array<uint8_t, crypto_hash_sha256_BYTES>& digest) {
-    std::vector<uint8_t> bytes_to_encode;
-    bytes_to_encode.insert(bytes_to_encode.end(), CID_PREFIX.begin(), CID_PREFIX.end());
-    bytes_to_encode.insert(bytes_to_encode.end(), digest.begin(), digest.end());
+std::string digest_to_cid(const sgns::utils::DigestArray &digest,
+                          HashAlgorithm algo) {
+  const auto &prefix =
+      algo == HashAlgorithm::SHA256 ? CID_PREFIX_SHA256 : CID_PREFIX_BLAKE3;
+  std::vector<uint8_t> bytes_to_encode;
+  bytes_to_encode.insert(bytes_to_encode.end(), prefix.begin(), prefix.end());
+  bytes_to_encode.insert(bytes_to_encode.end(), digest.begin(), digest.end());
 
-    return cppcodec::base32_rfc4648::encode(bytes_to_encode);
+  return cppcodec::base32_rfc4648::encode(bytes_to_encode);
 }
 
-std::array<uint8_t, crypto_hash_sha256_BYTES> cid_to_digest(const std::string& cid) {
-    if (cid.empty()) {
-        throw std::runtime_error("CID string cannot be empty.");
-    }
+DigestArray cid_to_digest(const std::string &cid, HashAlgorithm *algo_out) {
+  if (cid.empty()) {
+    throw std::runtime_error("CID string cannot be empty.");
+  }
 
-    // Base32 decoding typically expects uppercase, but RFC4648 says it can be upper or lower.
-    // cpp-base32 handles both, but let's ensure we pass what it expects if there are issues.
-    // For now, we assume it handles mixed case or we convert to uppercase if necessary.
-    std::vector<uint8_t> decoded_bytes;
-    try {
-        // cppcodec's decode function takes a pointer and a size, or a range.
-        // Using a range-based version or ensuring the input is null-terminated if using char*
-        decoded_bytes = cppcodec::base32_rfc4648::decode(cid.data(), cid.length());
-    } catch (const std::exception& e) {
-        throw std::runtime_error("Failed to decode Base32 CID: " + std::string(e.what()));
-    }
+  // Base32 decoding typically expects uppercase, but RFC4648 says it can be
+  // upper or lower. cpp-base32 handles both, but let's ensure we pass what it
+  // expects if there are issues. For now, we assume it handles mixed case or we
+  // convert to uppercase if necessary.
+  std::vector<uint8_t> decoded_bytes;
+  try {
+    // cppcodec's decode function takes a pointer and a size, or a range.
+    // Using a range-based version or ensuring the input is null-terminated if
+    // using char*
+    decoded_bytes = cppcodec::base32_rfc4648::decode(cid.data(), cid.length());
+  } catch (const std::exception &e) {
+    throw std::runtime_error("Failed to decode Base32 CID: " +
+                             std::string(e.what()));
+  }
 
+  if (decoded_bytes.size() < CID_PREFIX_BLAKE3.size()) {
+    throw std::runtime_error(
+        "Invalid CID: Decoded data too short to contain prefix.");
+  }
 
-    if (decoded_bytes.size() < CID_PREFIX.size()) {
-        throw std::runtime_error("Invalid CID: Decoded data too short to contain prefix.");
-    }
+  const std::vector<uint8_t> *prefix = nullptr;
+  HashAlgorithm algo;
+  if (std::equal(decoded_bytes.begin(),
+                 decoded_bytes.begin() + CID_PREFIX_SHA256.size(),
+                 CID_PREFIX_SHA256.begin())) {
+    prefix = &CID_PREFIX_SHA256;
+    algo = HashAlgorithm::SHA256;
+  } else if (std::equal(decoded_bytes.begin(),
+                        decoded_bytes.begin() + CID_PREFIX_BLAKE3.size(),
+                        CID_PREFIX_BLAKE3.begin())) {
+    prefix = &CID_PREFIX_BLAKE3;
+    algo = HashAlgorithm::BLAKE3;
+  } else {
+    throw std::runtime_error("Invalid CID: Prefix mismatch.");
+  }
 
-    // Verify prefix
-    for (size_t i = 0; i < CID_PREFIX.size(); ++i) {
-        if (decoded_bytes[i] != CID_PREFIX[i]) {
-            throw std::runtime_error("Invalid CID: Prefix mismatch.");
-        }
-    }
+  size_t expected_digest_size = sgns::utils::DIGEST_SIZE;
+  if (decoded_bytes.size() != prefix->size() + expected_digest_size) {
+    throw std::runtime_error("Invalid CID: Decoded data length does not match "
+                             "expected digest size.");
+  }
 
-    size_t expected_digest_size = crypto_hash_sha256_BYTES;
-    if (decoded_bytes.size() != CID_PREFIX.size() + expected_digest_size) {
-        throw std::runtime_error("Invalid CID: Decoded data length does not match expected digest size.");
-    }
+  DigestArray digest;
+  std::copy(decoded_bytes.begin() + prefix->size(), decoded_bytes.end(),
+            digest.begin());
 
-    std::array<uint8_t, crypto_hash_sha256_BYTES> digest;
-    std::copy(decoded_bytes.begin() + CID_PREFIX.size(), decoded_bytes.end(), digest.begin());
+  if (algo_out) {
+    *algo_out = algo;
+  }
 
-    return digest;
+  return digest;
 }
 
-std::vector<uint8_t> cid_to_bytes(const std::string& cid) {
-    auto digest = cid_to_digest(cid);
-    std::vector<uint8_t> bytes;
-    bytes.insert(bytes.end(), CID_PREFIX.begin(), CID_PREFIX.end());
-    bytes.insert(bytes.end(), digest.begin(), digest.end());
-    return bytes;
+std::vector<uint8_t> cid_to_bytes(const std::string &cid) {
+  HashAlgorithm algo;
+  auto digest = cid_to_digest(cid, &algo);
+  const auto &prefix =
+      algo == HashAlgorithm::SHA256 ? CID_PREFIX_SHA256 : CID_PREFIX_BLAKE3;
+  std::vector<uint8_t> bytes;
+  bytes.insert(bytes.end(), prefix.begin(), prefix.end());
+  bytes.insert(bytes.end(), digest.begin(), digest.end());
+  return bytes;
 }
 
 } // namespace sgns::utils

--- a/src/utilities/fips.cpp
+++ b/src/utilities/fips.cpp
@@ -1,21 +1,22 @@
 #include "utilities/fips.h"
-#include <sodium.h>
+#include "blake3.h"
 #include <cstring>
+#include <sodium.h>
 
 bool fips_self_test() {
-    if (sodium_init() < 0) {
-        return false;
-    }
-    const char msg[] = "The quick brown fox jumps over the lazy dog";
-    unsigned char digest[crypto_hash_sha256_BYTES];
-    crypto_hash_sha256(digest,
-                       reinterpret_cast<const unsigned char*>(msg),
+  if (sodium_init() < 0) {
+    return false;
+  }
+  const char msg[] = "The quick brown fox jumps over the lazy dog";
+  unsigned char digest[BLAKE3_OUT_LEN];
+  blake3_hasher hasher;
+  blake3_hasher_init(&hasher);
+  blake3_hasher_update(&hasher, reinterpret_cast<const uint8_t *>(msg),
                        sizeof(msg) - 1);
-    const unsigned char expected[crypto_hash_sha256_BYTES] = {
-        0xd7,0xa8,0xfb,0xb3,0x07,0xd7,0x80,0x94,
-        0x69,0xca,0x9a,0xbc,0xb0,0x08,0x2e,0x4f,
-        0x8d,0x56,0x51,0xe4,0x6d,0x3c,0xdb,0x76,
-        0x2d,0x02,0xd0,0xbf,0x37,0xc9,0xe5,0x92
-    };
-    return std::memcmp(digest, expected, crypto_hash_sha256_BYTES) == 0;
+  blake3_hasher_finalize(&hasher, digest, BLAKE3_OUT_LEN);
+  const unsigned char expected[BLAKE3_OUT_LEN] = {
+      0x2f, 0x15, 0x14, 0x18, 0x1a, 0xad, 0xcc, 0xd9, 0x13, 0xab, 0xd9,
+      0x4c, 0xfa, 0x59, 0x27, 0x01, 0xa5, 0x68, 0x6a, 0xb2, 0x3f, 0x8d,
+      0xf1, 0xdf, 0xf1, 0xb7, 0x47, 0x10, 0xfe, 0xbc, 0x6d, 0x4a};
+  return std::memcmp(digest, expected, BLAKE3_OUT_LEN) == 0;
 }

--- a/tests/cid_tests.cpp
+++ b/tests/cid_tests.cpp
@@ -1,101 +1,124 @@
-#include "gtest/gtest.h" // Google Test header
 #include "utilities/cid_utils.hpp"
-#include "utilities/blockio.hpp" // For crypto_hash_sha256_BYTES definition (and uint8_t if included there)
+#include "utilities/digest.hpp"
+#include "gtest/gtest.h" // Google Test header
 
-#include <vector>
-#include <array>
-#include <random>   // For std::random_device, std::mt19937, std::uniform_int_distribution
-#include <iostream> // For potential debug output (optional)
-#include <cstdint>  // For uint8_t
-#include <stdexcept> // For std::runtime_error
 #include "cppcodec/base32_rfc4648.hpp" // For encoding test data
+#include <array>
+#include <cstdint>  // For uint8_t
+#include <iostream> // For potential debug output (optional)
+#include <random> // For std::random_device, std::mt19937, std::uniform_int_distribution
+#include <stdexcept> // For std::runtime_error
+#include <vector>
 
 // Fuzz test for CID conversion
 TEST(CIDConversionFuzzTest, RoundTripConsistency) {
-    const int num_iterations = 10000;
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_int_distribution<uint8_t> distrib(0, 255);
+  const int num_iterations = 10000;
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<uint8_t> distrib(0, 255);
 
-    for (int i = 0; i < num_iterations; ++i) {
-        std::array<uint8_t, crypto_hash_sha256_BYTES> original_digest;
-        for (size_t j = 0; j < crypto_hash_sha256_BYTES; ++j) {
-            original_digest[j] = distrib(gen);
-        }
-
-        // Convert digest to CID
-        std::string cid_str;
-        ASSERT_NO_THROW(cid_str = sgns::utils::digest_to_cid(original_digest));
-
-        // Convert CID back to digest
-        std::array<uint8_t, crypto_hash_sha256_BYTES> round_tripped_digest;
-        ASSERT_NO_THROW(round_tripped_digest = sgns::utils::cid_to_digest(cid_str));
-
-        // Assert that the original and round-tripped digests are identical
-        ASSERT_EQ(original_digest, round_tripped_digest);
-
-        // Optional: print progress or a sample CID
-        // if (i % 1000 == 0 && i > 0) {
-        //     std::cout << "Fuzz test iteration: " << i << ", CID: " << cid_str << std::endl;
-        // }
+  for (int i = 0; i < num_iterations; ++i) {
+    std::array<uint8_t, sgns::utils::DIGEST_SIZE> original_digest;
+    for (size_t j = 0; j < sgns::utils::DIGEST_SIZE; ++j) {
+      original_digest[j] = distrib(gen);
     }
+
+    // Convert digest to CID
+    std::string cid_str;
+    ASSERT_NO_THROW(cid_str = sgns::utils::digest_to_cid(original_digest));
+
+    // Convert CID back to digest
+    std::array<uint8_t, sgns::utils::DIGEST_SIZE> round_tripped_digest;
+    ASSERT_NO_THROW(round_tripped_digest = sgns::utils::cid_to_digest(cid_str));
+
+    // Assert that the original and round-tripped digests are identical
+    ASSERT_EQ(original_digest, round_tripped_digest);
+
+    // Optional: print progress or a sample CID
+    // if (i % 1000 == 0 && i > 0) {
+    //     std::cout << "Fuzz test iteration: " << i << ", CID: " << cid_str <<
+    //     std::endl;
+    // }
+  }
 }
 
 // Test cases for invalid CID inputs
 TEST(CIDInvalidInputTest, HandlesInvalidCIDs) {
-    // 1. Empty CID
-    std::string empty_cid = "";
-    ASSERT_THROW(sgns::utils::cid_to_digest(empty_cid), std::runtime_error);
+  // 1. Empty CID
+  std::string empty_cid = "";
+  ASSERT_THROW(sgns::utils::cid_to_digest(empty_cid), std::runtime_error);
 
-    // 2. CID too short (after base32 decoding) to contain prefix
-    std::string short_cid_prefix = "b"; // Decodes to too few bytes for prefix
-    ASSERT_THROW(sgns::utils::cid_to_digest(short_cid_prefix), std::runtime_error);
+  // 2. CID too short (after base32 decoding) to contain prefix
+  std::string short_cid_prefix = "b"; // Decodes to too few bytes for prefix
+  ASSERT_THROW(sgns::utils::cid_to_digest(short_cid_prefix),
+               std::runtime_error);
 
-    std::string short_cid_slightly_longer = "bahca"; // prefix is 0x01, 0x70 - still too short for full prefix
-    ASSERT_THROW(sgns::utils::cid_to_digest(short_cid_slightly_longer), std::runtime_error);
+  std::string short_cid_slightly_longer =
+      "bahca"; // prefix is 0x01, 0x70 - still too short for full prefix
+  ASSERT_THROW(sgns::utils::cid_to_digest(short_cid_slightly_longer),
+               std::runtime_error);
 
-    // 3. CID with invalid Base32 characters
-    // A valid prefix + valid hash length + invalid base32 characters for the hash part
-    std::array<uint8_t, crypto_hash_sha256_BYTES> dummy_digest;
-    dummy_digest.fill(0);
-    std::string valid_cid_start = sgns::utils::digest_to_cid(dummy_digest);
-    std::string invalid_base32_cid = valid_cid_start.substr(0, valid_cid_start.length() -1 ) + "!"; // '!' is not valid base32
-    ASSERT_THROW(sgns::utils::cid_to_digest(invalid_base32_cid), std::runtime_error); // cppcodec throws std::out_of_range for this, caught as runtime_error in cid_utils
+  // 3. CID with invalid Base32 characters
+  // A valid prefix + valid hash length + invalid base32 characters for the hash
+  // part
+  std::array<uint8_t, sgns::utils::DIGEST_SIZE> dummy_digest;
+  dummy_digest.fill(0);
+  std::string valid_cid_start = sgns::utils::digest_to_cid(dummy_digest);
+  std::string invalid_base32_cid =
+      valid_cid_start.substr(0, valid_cid_start.length() - 1) +
+      "!"; // '!' is not valid base32
+  ASSERT_THROW(
+      sgns::utils::cid_to_digest(invalid_base32_cid),
+      std::runtime_error); // cppcodec throws std::out_of_range for this, caught
+                           // as runtime_error in cid_utils
 
-    // 4. CID with correct Base32 but wrong prefix (e.g., wrong CID version)
-    std::vector<uint8_t> bad_prefix_bytes = {0x02, 0x70, 0x12, 0x20}; // Changed 0x01 to 0x02
-    for(int i=0; i<32; ++i) bad_prefix_bytes.push_back(static_cast<uint8_t>(i)); // Dummy data
-    std::string bad_prefix_cid;
-    ASSERT_NO_THROW(bad_prefix_cid = cppcodec::base32_rfc4648::encode(bad_prefix_bytes));
-    ASSERT_THROW(sgns::utils::cid_to_digest(bad_prefix_cid), std::runtime_error);
+  // 4. CID with correct Base32 but wrong prefix (e.g., wrong CID version)
+  std::vector<uint8_t> bad_prefix_bytes = {0x02, 0x70, 0x12,
+                                           0x20}; // Changed 0x01 to 0x02
+  for (int i = 0; i < 32; ++i)
+    bad_prefix_bytes.push_back(static_cast<uint8_t>(i)); // Dummy data
+  std::string bad_prefix_cid;
+  ASSERT_NO_THROW(bad_prefix_cid =
+                      cppcodec::base32_rfc4648::encode(bad_prefix_bytes));
+  ASSERT_THROW(sgns::utils::cid_to_digest(bad_prefix_cid), std::runtime_error);
 
-    // 5. CID with correct prefix but wrong length field in prefix (e.g., 0x21 instead of 0x20)
-    std::vector<uint8_t> bad_length_bytes = {0x01, 0x70, 0x12, 0x21}; // 0x21 = 33 bytes length
-    for(int i=0; i<32; ++i) bad_length_bytes.push_back(static_cast<uint8_t>(i)); // Still 32 bytes of actual data after prefix
-    std::string bad_length_cid;
-    ASSERT_NO_THROW(bad_length_cid = cppcodec::base32_rfc4648::encode(bad_length_bytes));
-    ASSERT_THROW(sgns::utils::cid_to_digest(bad_length_cid), std::runtime_error); // Expects 33 bytes of hash, gets 32.
+  // 5. CID with correct prefix but wrong length field in prefix (e.g., 0x21
+  // instead of 0x20)
+  std::vector<uint8_t> bad_length_bytes = {0x01, 0x70, 0x12,
+                                           0x21}; // 0x21 = 33 bytes length
+  for (int i = 0; i < 32; ++i)
+    bad_length_bytes.push_back(
+        static_cast<uint8_t>(i)); // Still 32 bytes of actual data after prefix
+  std::string bad_length_cid;
+  ASSERT_NO_THROW(bad_length_cid =
+                      cppcodec::base32_rfc4648::encode(bad_length_bytes));
+  ASSERT_THROW(sgns::utils::cid_to_digest(bad_length_cid),
+               std::runtime_error); // Expects 33 bytes of hash, gets 32.
 
-    // 6. CID with correct prefix and length field, but actual data is too short
-    std::vector<uint8_t> short_data_bytes = {0x01, 0x70, 0x12, 0x20}; // Expects 32 bytes of hash
-    for(int i=0; i<31; ++i) short_data_bytes.push_back(static_cast<uint8_t>(i)); // Only 31 bytes of data provided after prefix
-    std::string short_data_cid;
-    ASSERT_NO_THROW(short_data_cid = cppcodec::base32_rfc4648::encode(short_data_bytes));
-    ASSERT_THROW(sgns::utils::cid_to_digest(short_data_cid), std::runtime_error); // Decoded data too short overall.
+  // 6. CID with correct prefix and length field, but actual data is too short
+  std::vector<uint8_t> short_data_bytes = {0x01, 0x70, 0x12,
+                                           0x20}; // Expects 32 bytes of hash
+  for (int i = 0; i < 31; ++i)
+    short_data_bytes.push_back(
+        static_cast<uint8_t>(i)); // Only 31 bytes of data provided after prefix
+  std::string short_data_cid;
+  ASSERT_NO_THROW(short_data_cid =
+                      cppcodec::base32_rfc4648::encode(short_data_bytes));
+  ASSERT_THROW(sgns::utils::cid_to_digest(short_data_cid),
+               std::runtime_error); // Decoded data too short overall.
 }
 
 TEST(CIDToBytesTest, ProducesCorrectByteVector) {
-    std::array<uint8_t, crypto_hash_sha256_BYTES> digest;
-    for (size_t i = 0; i < digest.size(); ++i) {
-        digest[i] = static_cast<uint8_t>(i);
-    }
-    std::string cid = sgns::utils::digest_to_cid(digest);
+  std::array<uint8_t, sgns::utils::DIGEST_SIZE> digest;
+  for (size_t i = 0; i < digest.size(); ++i) {
+    digest[i] = static_cast<uint8_t>(i);
+  }
+  std::string cid = sgns::utils::digest_to_cid(digest);
 
-    std::vector<uint8_t> result = sgns::utils::cid_to_bytes(cid);
+  std::vector<uint8_t> result = sgns::utils::cid_to_bytes(cid);
 
-    std::vector<uint8_t> expected(sgns::utils::CID_PREFIX.begin(), sgns::utils::CID_PREFIX.end());
-    expected.insert(expected.end(), digest.begin(), digest.end());
-
-    ASSERT_EQ(result, expected);
+  std::vector<uint8_t> expected(sgns::utils::CID_PREFIX_BLAKE3.begin(),
+                                sgns::utils::CID_PREFIX_BLAKE3.end());
+  expected.insert(expected.end(), digest.begin(), digest.end());
+  ASSERT_EQ(result, expected);
 }
-

--- a/third_party/blake3/CMakeLists.txt
+++ b/third_party/blake3/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.10)
+project(blake3 C)
+
+add_library(blake3 STATIC
+    blake3.c
+    blake3_dispatch.c
+    blake3_portable.c
+)
+
+target_include_directories(blake3 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_compile_definitions(blake3 PUBLIC
+    BLAKE3_NO_AVX2=1
+    BLAKE3_NO_AVX512=1
+    BLAKE3_NO_SSE2=1
+    BLAKE3_NO_SSE41=1
+    BLAKE3_USE_NEON=0
+)

--- a/third_party/blake3/LICENSE_A2
+++ b/third_party/blake3/LICENSE_A2
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 Jack O'Connor and Samuel Neves
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/blake3/LICENSE_A2LLVM
+++ b/third_party/blake3/LICENSE_A2LLVM
@@ -1,0 +1,219 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright 2019 Jack O'Connor and Samuel Neves
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+---- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+

--- a/third_party/blake3/LICENSE_CC0
+++ b/third_party/blake3/LICENSE_CC0
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/third_party/blake3/blake3.c
+++ b/third_party/blake3/blake3.c
@@ -1,0 +1,657 @@
+// SPDX-License-Identifier: CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH
+// LLVM-exception
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "blake3.h"
+#include "blake3_impl.h"
+
+const char *blake3_version(void) { return BLAKE3_VERSION_STRING; }
+
+INLINE void chunk_state_init(blake3_chunk_state *self, const uint32_t key[8],
+                             uint8_t flags) {
+  memcpy(self->cv, key, BLAKE3_KEY_LEN);
+  self->chunk_counter = 0;
+  memset(self->buf, 0, BLAKE3_BLOCK_LEN);
+  self->buf_len = 0;
+  self->blocks_compressed = 0;
+  self->flags = flags;
+}
+
+INLINE void chunk_state_reset(blake3_chunk_state *self, const uint32_t key[8],
+                              uint64_t chunk_counter) {
+  memcpy(self->cv, key, BLAKE3_KEY_LEN);
+  self->chunk_counter = chunk_counter;
+  self->blocks_compressed = 0;
+  memset(self->buf, 0, BLAKE3_BLOCK_LEN);
+  self->buf_len = 0;
+}
+
+INLINE size_t chunk_state_len(const blake3_chunk_state *self) {
+  return (BLAKE3_BLOCK_LEN * (size_t)self->blocks_compressed) +
+         ((size_t)self->buf_len);
+}
+
+INLINE size_t chunk_state_fill_buf(blake3_chunk_state *self,
+                                   const uint8_t *input, size_t input_len) {
+  size_t take = BLAKE3_BLOCK_LEN - ((size_t)self->buf_len);
+  if (take > input_len) {
+    take = input_len;
+  }
+  uint8_t *dest = self->buf + ((size_t)self->buf_len);
+  memcpy(dest, input, take);
+  self->buf_len += (uint8_t)take;
+  return take;
+}
+
+INLINE uint8_t chunk_state_maybe_start_flag(const blake3_chunk_state *self) {
+  if (self->blocks_compressed == 0) {
+    return CHUNK_START;
+  } else {
+    return 0;
+  }
+}
+
+typedef struct {
+  uint32_t input_cv[8];
+  uint64_t counter;
+  uint8_t block[BLAKE3_BLOCK_LEN];
+  uint8_t block_len;
+  uint8_t flags;
+} output_t;
+
+INLINE output_t make_output(const uint32_t input_cv[8],
+                            const uint8_t block[BLAKE3_BLOCK_LEN],
+                            uint8_t block_len, uint64_t counter,
+                            uint8_t flags) {
+  output_t ret;
+  memcpy(ret.input_cv, input_cv, 32);
+  memcpy(ret.block, block, BLAKE3_BLOCK_LEN);
+  ret.block_len = block_len;
+  ret.counter = counter;
+  ret.flags = flags;
+  return ret;
+}
+
+// Chaining values within a given chunk (specifically the compress_in_place
+// interface) are represented as words. This avoids unnecessary bytes<->words
+// conversion overhead in the portable implementation. However, the hash_many
+// interface handles both user input and parent node blocks, so it accepts
+// bytes. For that reason, chaining values in the CV stack are represented as
+// bytes.
+INLINE void output_chaining_value(const output_t *self, uint8_t cv[32]) {
+  uint32_t cv_words[8];
+  memcpy(cv_words, self->input_cv, 32);
+  blake3_compress_in_place(cv_words, self->block, self->block_len,
+                           self->counter, self->flags);
+  store_cv_words(cv, cv_words);
+}
+
+INLINE void output_root_bytes(const output_t *self, uint64_t seek, uint8_t *out,
+                              size_t out_len) {
+  if (out_len == 0) {
+    return;
+  }
+  uint64_t output_block_counter = seek / 64;
+  size_t offset_within_block = seek % 64;
+  uint8_t wide_buf[64];
+  if (offset_within_block) {
+    blake3_compress_xof(self->input_cv, self->block, self->block_len,
+                        output_block_counter, self->flags | ROOT, wide_buf);
+    const size_t available_bytes = 64 - offset_within_block;
+    const size_t bytes = out_len > available_bytes ? available_bytes : out_len;
+    memcpy(out, wide_buf + offset_within_block, bytes);
+    out += bytes;
+    out_len -= bytes;
+    output_block_counter += 1;
+  }
+  if (out_len / 64) {
+    blake3_xof_many(self->input_cv, self->block, self->block_len,
+                    output_block_counter, self->flags | ROOT, out,
+                    out_len / 64);
+  }
+  output_block_counter += out_len / 64;
+  out += out_len & -64;
+  out_len -= out_len & -64;
+  if (out_len) {
+    blake3_compress_xof(self->input_cv, self->block, self->block_len,
+                        output_block_counter, self->flags | ROOT, wide_buf);
+    memcpy(out, wide_buf, out_len);
+  }
+}
+
+INLINE void chunk_state_update(blake3_chunk_state *self, const uint8_t *input,
+                               size_t input_len) {
+  if (self->buf_len > 0) {
+    size_t take = chunk_state_fill_buf(self, input, input_len);
+    input += take;
+    input_len -= take;
+    if (input_len > 0) {
+      blake3_compress_in_place(
+          self->cv, self->buf, BLAKE3_BLOCK_LEN, self->chunk_counter,
+          self->flags | chunk_state_maybe_start_flag(self));
+      self->blocks_compressed += 1;
+      self->buf_len = 0;
+      memset(self->buf, 0, BLAKE3_BLOCK_LEN);
+    }
+  }
+
+  while (input_len > BLAKE3_BLOCK_LEN) {
+    blake3_compress_in_place(self->cv, input, BLAKE3_BLOCK_LEN,
+                             self->chunk_counter,
+                             self->flags | chunk_state_maybe_start_flag(self));
+    self->blocks_compressed += 1;
+    input += BLAKE3_BLOCK_LEN;
+    input_len -= BLAKE3_BLOCK_LEN;
+  }
+
+  chunk_state_fill_buf(self, input, input_len);
+}
+
+INLINE output_t chunk_state_output(const blake3_chunk_state *self) {
+  uint8_t block_flags =
+      self->flags | chunk_state_maybe_start_flag(self) | CHUNK_END;
+  return make_output(self->cv, self->buf, self->buf_len, self->chunk_counter,
+                     block_flags);
+}
+
+INLINE output_t parent_output(const uint8_t block[BLAKE3_BLOCK_LEN],
+                              const uint32_t key[8], uint8_t flags) {
+  return make_output(key, block, BLAKE3_BLOCK_LEN, 0, flags | PARENT);
+}
+
+// Given some input larger than one chunk, return the number of bytes that
+// should go in the left subtree. This is the largest power-of-2 number of
+// chunks that leaves at least 1 byte for the right subtree.
+INLINE size_t left_subtree_len(size_t input_len) {
+  // Subtract 1 to reserve at least one byte for the right side. input_len
+  // should always be greater than BLAKE3_CHUNK_LEN.
+  size_t full_chunks = (input_len - 1) / BLAKE3_CHUNK_LEN;
+  return round_down_to_power_of_2(full_chunks) * BLAKE3_CHUNK_LEN;
+}
+
+// Use SIMD parallelism to hash up to MAX_SIMD_DEGREE chunks at the same time
+// on a single thread. Write out the chunk chaining values and return the
+// number of chunks hashed. These chunks are never the root and never empty;
+// those cases use a different codepath.
+INLINE size_t compress_chunks_parallel(const uint8_t *input, size_t input_len,
+                                       const uint32_t key[8],
+                                       uint64_t chunk_counter, uint8_t flags,
+                                       uint8_t *out) {
+#if defined(BLAKE3_TESTING)
+  assert(0 < input_len);
+  assert(input_len <= MAX_SIMD_DEGREE * BLAKE3_CHUNK_LEN);
+#endif
+
+  const uint8_t *chunks_array[MAX_SIMD_DEGREE];
+  size_t input_position = 0;
+  size_t chunks_array_len = 0;
+  while (input_len - input_position >= BLAKE3_CHUNK_LEN) {
+    chunks_array[chunks_array_len] = &input[input_position];
+    input_position += BLAKE3_CHUNK_LEN;
+    chunks_array_len += 1;
+  }
+
+  blake3_hash_many(chunks_array, chunks_array_len,
+                   BLAKE3_CHUNK_LEN / BLAKE3_BLOCK_LEN, key, chunk_counter,
+                   true, flags, CHUNK_START, CHUNK_END, out);
+
+  // Hash the remaining partial chunk, if there is one. Note that the empty
+  // chunk (meaning the empty message) is a different codepath.
+  if (input_len > input_position) {
+    uint64_t counter = chunk_counter + (uint64_t)chunks_array_len;
+    blake3_chunk_state chunk_state;
+    chunk_state_init(&chunk_state, key, flags);
+    chunk_state.chunk_counter = counter;
+    chunk_state_update(&chunk_state, &input[input_position],
+                       input_len - input_position);
+    output_t output = chunk_state_output(&chunk_state);
+    output_chaining_value(&output, &out[chunks_array_len * BLAKE3_OUT_LEN]);
+    return chunks_array_len + 1;
+  } else {
+    return chunks_array_len;
+  }
+}
+
+// Use SIMD parallelism to hash up to MAX_SIMD_DEGREE parents at the same time
+// on a single thread. Write out the parent chaining values and return the
+// number of parents hashed. (If there's an odd input chaining value left over,
+// return it as an additional output.) These parents are never the root and
+// never empty; those cases use a different codepath.
+INLINE size_t compress_parents_parallel(const uint8_t *child_chaining_values,
+                                        size_t num_chaining_values,
+                                        const uint32_t key[8], uint8_t flags,
+                                        uint8_t *out) {
+#if defined(BLAKE3_TESTING)
+  assert(2 <= num_chaining_values);
+  assert(num_chaining_values <= 2 * MAX_SIMD_DEGREE_OR_2);
+#endif
+
+  const uint8_t *parents_array[MAX_SIMD_DEGREE_OR_2];
+  size_t parents_array_len = 0;
+  while (num_chaining_values - (2 * parents_array_len) >= 2) {
+    parents_array[parents_array_len] =
+        &child_chaining_values[2 * parents_array_len * BLAKE3_OUT_LEN];
+    parents_array_len += 1;
+  }
+
+  blake3_hash_many(parents_array, parents_array_len, 1, key,
+                   0, // Parents always use counter 0.
+                   false, flags | PARENT,
+                   0, // Parents have no start flags.
+                   0, // Parents have no end flags.
+                   out);
+
+  // If there's an odd child left over, it becomes an output.
+  if (num_chaining_values > 2 * parents_array_len) {
+    memcpy(&out[parents_array_len * BLAKE3_OUT_LEN],
+           &child_chaining_values[2 * parents_array_len * BLAKE3_OUT_LEN],
+           BLAKE3_OUT_LEN);
+    return parents_array_len + 1;
+  } else {
+    return parents_array_len;
+  }
+}
+
+// The wide helper function returns (writes out) an array of chaining values
+// and returns the length of that array. The number of chaining values returned
+// is the dynamically detected SIMD degree, at most MAX_SIMD_DEGREE. Or fewer,
+// if the input is shorter than that many chunks. The reason for maintaining a
+// wide array of chaining values going back up the tree, is to allow the
+// implementation to hash as many parents in parallel as possible.
+//
+// As a special case when the SIMD degree is 1, this function will still return
+// at least 2 outputs. This guarantees that this function doesn't perform the
+// root compression. (If it did, it would use the wrong flags, and also we
+// wouldn't be able to implement extendable output.) Note that this function is
+// not used when the whole input is only 1 chunk long; that's a different
+// codepath.
+//
+// Why not just have the caller split the input on the first update(), instead
+// of implementing this special rule? Because we don't want to limit SIMD or
+// multi-threading parallelism for that update().
+size_t blake3_compress_subtree_wide(const uint8_t *input, size_t input_len,
+                                    const uint32_t key[8],
+                                    uint64_t chunk_counter, uint8_t flags,
+                                    uint8_t *out, bool use_tbb) {
+  // Note that the single chunk case does *not* bump the SIMD degree up to 2
+  // when it is 1. If this implementation adds multi-threading in the future,
+  // this gives us the option of multi-threading even the 2-chunk case, which
+  // can help performance on smaller platforms.
+  if (input_len <= blake3_simd_degree() * BLAKE3_CHUNK_LEN) {
+    return compress_chunks_parallel(input, input_len, key, chunk_counter, flags,
+                                    out);
+  }
+
+  // With more than simd_degree chunks, we need to recurse. Start by dividing
+  // the input into left and right subtrees. (Note that this is only optimal
+  // as long as the SIMD degree is a power of 2. If we ever get a SIMD degree
+  // of 3 or something, we'll need a more complicated strategy.)
+  size_t left_input_len = left_subtree_len(input_len);
+  size_t right_input_len = input_len - left_input_len;
+  const uint8_t *right_input = &input[left_input_len];
+  uint64_t right_chunk_counter =
+      chunk_counter + (uint64_t)(left_input_len / BLAKE3_CHUNK_LEN);
+
+  // Make space for the child outputs. Here we use MAX_SIMD_DEGREE_OR_2 to
+  // account for the special case of returning 2 outputs when the SIMD degree
+  // is 1.
+  uint8_t cv_array[2 * MAX_SIMD_DEGREE_OR_2 * BLAKE3_OUT_LEN];
+  size_t degree = blake3_simd_degree();
+  if (left_input_len > BLAKE3_CHUNK_LEN && degree == 1) {
+    // The special case: We always use a degree of at least two, to make
+    // sure there are two outputs. Except, as noted above, at the chunk
+    // level, where we allow degree=1. (Note that the 1-chunk-input case is
+    // a different codepath.)
+    degree = 2;
+  }
+  uint8_t *right_cvs = &cv_array[degree * BLAKE3_OUT_LEN];
+
+  // Recurse!
+  size_t left_n = -1;
+  size_t right_n = -1;
+
+#if defined(BLAKE3_USE_TBB)
+  blake3_compress_subtree_wide_join_tbb(
+      key, flags, use_tbb,
+      // left-hand side
+      input, left_input_len, chunk_counter, cv_array, &left_n,
+      // right-hand side
+      right_input, right_input_len, right_chunk_counter, right_cvs, &right_n);
+#else
+  left_n = blake3_compress_subtree_wide(
+      input, left_input_len, key, chunk_counter, flags, cv_array, use_tbb);
+  right_n = blake3_compress_subtree_wide(right_input, right_input_len, key,
+                                         right_chunk_counter, flags, right_cvs,
+                                         use_tbb);
+#endif // BLAKE3_USE_TBB
+
+  // The special case again. If simd_degree=1, then we'll have left_n=1 and
+  // right_n=1. Rather than compressing them into a single output, return
+  // them directly, to make sure we always have at least two outputs.
+  if (left_n == 1) {
+    memcpy(out, cv_array, 2 * BLAKE3_OUT_LEN);
+    return 2;
+  }
+
+  // Otherwise, do one layer of parent node compression.
+  size_t num_chaining_values = left_n + right_n;
+  return compress_parents_parallel(cv_array, num_chaining_values, key, flags,
+                                   out);
+}
+
+// Hash a subtree with compress_subtree_wide(), and then condense the resulting
+// list of chaining values down to a single parent node. Don't compress that
+// last parent node, however. Instead, return its message bytes (the
+// concatenated chaining values of its children). This is necessary when the
+// first call to update() supplies a complete subtree, because the topmost
+// parent node of that subtree could end up being the root. It's also necessary
+// for extended output in the general case.
+//
+// As with compress_subtree_wide(), this function is not used on inputs of 1
+// chunk or less. That's a different codepath.
+INLINE void
+compress_subtree_to_parent_node(const uint8_t *input, size_t input_len,
+                                const uint32_t key[8], uint64_t chunk_counter,
+                                uint8_t flags, uint8_t out[2 * BLAKE3_OUT_LEN],
+                                bool use_tbb) {
+#if defined(BLAKE3_TESTING)
+  assert(input_len > BLAKE3_CHUNK_LEN);
+#endif
+
+  uint8_t cv_array[MAX_SIMD_DEGREE_OR_2 * BLAKE3_OUT_LEN];
+  size_t num_cvs = blake3_compress_subtree_wide(
+      input, input_len, key, chunk_counter, flags, cv_array, use_tbb);
+  assert(num_cvs <= MAX_SIMD_DEGREE_OR_2);
+  // The following loop never executes when MAX_SIMD_DEGREE_OR_2 is 2, because
+  // as we just asserted, num_cvs will always be <=2 in that case. But GCC
+  // (particularly GCC 8.5) can't tell that it never executes, and if NDEBUG is
+  // set then it emits incorrect warnings here. We tried a few different
+  // hacks to silence these, but in the end our hacks just produced different
+  // warnings (see https://github.com/BLAKE3-team/BLAKE3/pull/380). Out of
+  // desperation, we ifdef out this entire loop when we know it's not needed.
+#if MAX_SIMD_DEGREE_OR_2 > 2
+  // If MAX_SIMD_DEGREE_OR_2 is greater than 2 and there's enough input,
+  // compress_subtree_wide() returns more than 2 chaining values. Condense
+  // them into 2 by forming parent nodes repeatedly.
+  uint8_t out_array[MAX_SIMD_DEGREE_OR_2 * BLAKE3_OUT_LEN / 2];
+  while (num_cvs > 2) {
+    num_cvs =
+        compress_parents_parallel(cv_array, num_cvs, key, flags, out_array);
+    memcpy(cv_array, out_array, num_cvs * BLAKE3_OUT_LEN);
+  }
+#endif
+  memcpy(out, cv_array, 2 * BLAKE3_OUT_LEN);
+}
+
+INLINE void hasher_init_base(blake3_hasher *self, const uint32_t key[8],
+                             uint8_t flags) {
+  memcpy(self->key, key, BLAKE3_KEY_LEN);
+  chunk_state_init(&self->chunk, key, flags);
+  self->cv_stack_len = 0;
+}
+
+void blake3_hasher_init(blake3_hasher *self) { hasher_init_base(self, IV, 0); }
+
+void blake3_hasher_init_keyed(blake3_hasher *self,
+                              const uint8_t key[BLAKE3_KEY_LEN]) {
+  uint32_t key_words[8];
+  load_key_words(key, key_words);
+  hasher_init_base(self, key_words, KEYED_HASH);
+}
+
+void blake3_hasher_init_derive_key_raw(blake3_hasher *self, const void *context,
+                                       size_t context_len) {
+  blake3_hasher context_hasher;
+  hasher_init_base(&context_hasher, IV, DERIVE_KEY_CONTEXT);
+  blake3_hasher_update(&context_hasher, context, context_len);
+  uint8_t context_key[BLAKE3_KEY_LEN];
+  blake3_hasher_finalize(&context_hasher, context_key, BLAKE3_KEY_LEN);
+  uint32_t context_key_words[8];
+  load_key_words(context_key, context_key_words);
+  hasher_init_base(self, context_key_words, DERIVE_KEY_MATERIAL);
+}
+
+void blake3_hasher_init_derive_key(blake3_hasher *self, const char *context) {
+  blake3_hasher_init_derive_key_raw(self, context, strlen(context));
+}
+
+// As described in hasher_push_cv() below, we do "lazy merging", delaying
+// merges until right before the next CV is about to be added. This is
+// different from the reference implementation. Another difference is that we
+// aren't always merging 1 chunk at a time. Instead, each CV might represent
+// any power-of-two number of chunks, as long as the smaller-above-larger stack
+// order is maintained. Instead of the "count the trailing 0-bits" algorithm
+// described in the spec, we use a "count the total number of 1-bits" variant
+// that doesn't require us to retain the subtree size of the CV on top of the
+// stack. The principle is the same: each CV that should remain in the stack is
+// represented by a 1-bit in the total number of chunks (or bytes) so far.
+INLINE void hasher_merge_cv_stack(blake3_hasher *self, uint64_t total_len) {
+  size_t post_merge_stack_len = (size_t)popcnt(total_len);
+  while (self->cv_stack_len > post_merge_stack_len) {
+    uint8_t *parent_node =
+        &self->cv_stack[(self->cv_stack_len - 2) * BLAKE3_OUT_LEN];
+    output_t output = parent_output(parent_node, self->key, self->chunk.flags);
+    output_chaining_value(&output, parent_node);
+    self->cv_stack_len -= 1;
+  }
+}
+
+// In reference_impl.rs, we merge the new CV with existing CVs from the stack
+// before pushing it. We can do that because we know more input is coming, so
+// we know none of the merges are root.
+//
+// This setting is different. We want to feed as much input as possible to
+// compress_subtree_wide(), without setting aside anything for the chunk_state.
+// If the user gives us 64 KiB, we want to parallelize over all 64 KiB at once
+// as a single subtree, if at all possible.
+//
+// This leads to two problems:
+// 1) This 64 KiB input might be the only call that ever gets made to update.
+//    In this case, the root node of the 64 KiB subtree would be the root node
+//    of the whole tree, and it would need to be ROOT finalized. We can't
+//    compress it until we know.
+// 2) This 64 KiB input might complete a larger tree, whose root node is
+//    similarly going to be the root of the whole tree. For example, maybe
+//    we have 196 KiB (that is, 128 + 64) hashed so far. We can't compress the
+//    node at the root of the 256 KiB subtree until we know how to finalize it.
+//
+// The second problem is solved with "lazy merging". That is, when we're about
+// to add a CV to the stack, we don't merge it with anything first, as the
+// reference impl does. Instead we do merges using the *previous* CV that was
+// added, which is sitting on top of the stack, and we put the new CV
+// (unmerged) on top of the stack afterwards. This guarantees that we never
+// merge the root node until finalize().
+//
+// Solving the first problem requires an additional tool,
+// compress_subtree_to_parent_node(). That function always returns the top
+// *two* chaining values of the subtree it's compressing. We then do lazy
+// merging with each of them separately, so that the second CV will always
+// remain unmerged. (That also helps us support extendable output when we're
+// hashing an input all-at-once.)
+INLINE void hasher_push_cv(blake3_hasher *self, uint8_t new_cv[BLAKE3_OUT_LEN],
+                           uint64_t chunk_counter) {
+  hasher_merge_cv_stack(self, chunk_counter);
+  memcpy(&self->cv_stack[self->cv_stack_len * BLAKE3_OUT_LEN], new_cv,
+         BLAKE3_OUT_LEN);
+  self->cv_stack_len += 1;
+}
+
+INLINE void blake3_hasher_update_base(blake3_hasher *self, const void *input,
+                                      size_t input_len, bool use_tbb) {
+  // Explicitly checking for zero avoids causing UB by passing a null pointer
+  // to memcpy. This comes up in practice with things like:
+  //   std::vector<uint8_t> v;
+  //   blake3_hasher_update(&hasher, v.data(), v.size());
+  if (input_len == 0) {
+    return;
+  }
+
+  const uint8_t *input_bytes = (const uint8_t *)input;
+
+  // If we have some partial chunk bytes in the internal chunk_state, we need
+  // to finish that chunk first.
+  if (chunk_state_len(&self->chunk) > 0) {
+    size_t take = BLAKE3_CHUNK_LEN - chunk_state_len(&self->chunk);
+    if (take > input_len) {
+      take = input_len;
+    }
+    chunk_state_update(&self->chunk, input_bytes, take);
+    input_bytes += take;
+    input_len -= take;
+    // If we've filled the current chunk and there's more coming, finalize this
+    // chunk and proceed. In this case we know it's not the root.
+    if (input_len > 0) {
+      output_t output = chunk_state_output(&self->chunk);
+      uint8_t chunk_cv[32];
+      output_chaining_value(&output, chunk_cv);
+      hasher_push_cv(self, chunk_cv, self->chunk.chunk_counter);
+      chunk_state_reset(&self->chunk, self->key, self->chunk.chunk_counter + 1);
+    } else {
+      return;
+    }
+  }
+
+  // Now the chunk_state is clear, and we have more input. If there's more than
+  // a single chunk (so, definitely not the root chunk), hash the largest whole
+  // subtree we can, with the full benefits of SIMD (and maybe in the future,
+  // multi-threading) parallelism. Two restrictions:
+  // - The subtree has to be a power-of-2 number of chunks. Only subtrees along
+  //   the right edge can be incomplete, and we don't know where the right edge
+  //   is going to be until we get to finalize().
+  // - The subtree must evenly divide the total number of chunks up until this
+  //   point (if total is not 0). If the current incomplete subtree is only
+  //   waiting for 1 more chunk, we can't hash a subtree of 4 chunks. We have
+  //   to complete the current subtree first.
+  // Because we might need to break up the input to form powers of 2, or to
+  // evenly divide what we already have, this part runs in a loop.
+  while (input_len > BLAKE3_CHUNK_LEN) {
+    size_t subtree_len = round_down_to_power_of_2(input_len);
+    uint64_t count_so_far = self->chunk.chunk_counter * BLAKE3_CHUNK_LEN;
+    // Shrink the subtree_len until it evenly divides the count so far. We know
+    // that subtree_len itself is a power of 2, so we can use a bitmasking
+    // trick instead of an actual remainder operation. (Note that if the caller
+    // consistently passes power-of-2 inputs of the same size, as is hopefully
+    // typical, this loop condition will always fail, and subtree_len will
+    // always be the full length of the input.)
+    //
+    // An aside: We don't have to shrink subtree_len quite this much. For
+    // example, if count_so_far is 1, we could pass 2 chunks to
+    // compress_subtree_to_parent_node. Since we'll get 2 CVs back, we'll still
+    // get the right answer in the end, and we might get to use 2-way SIMD
+    // parallelism. The problem with this optimization, is that it gets us
+    // stuck always hashing 2 chunks. The total number of chunks will remain
+    // odd, and we'll never graduate to higher degrees of parallelism. See
+    // https://github.com/BLAKE3-team/BLAKE3/issues/69.
+    while ((((uint64_t)(subtree_len - 1)) & count_so_far) != 0) {
+      subtree_len /= 2;
+    }
+    // The shrunken subtree_len might now be 1 chunk long. If so, hash that one
+    // chunk by itself. Otherwise, compress the subtree into a pair of CVs.
+    uint64_t subtree_chunks = subtree_len / BLAKE3_CHUNK_LEN;
+    if (subtree_len <= BLAKE3_CHUNK_LEN) {
+      blake3_chunk_state chunk_state;
+      chunk_state_init(&chunk_state, self->key, self->chunk.flags);
+      chunk_state.chunk_counter = self->chunk.chunk_counter;
+      chunk_state_update(&chunk_state, input_bytes, subtree_len);
+      output_t output = chunk_state_output(&chunk_state);
+      uint8_t cv[BLAKE3_OUT_LEN];
+      output_chaining_value(&output, cv);
+      hasher_push_cv(self, cv, chunk_state.chunk_counter);
+    } else {
+      // This is the high-performance happy path, though getting here depends
+      // on the caller giving us a long enough input.
+      uint8_t cv_pair[2 * BLAKE3_OUT_LEN];
+      compress_subtree_to_parent_node(input_bytes, subtree_len, self->key,
+                                      self->chunk.chunk_counter,
+                                      self->chunk.flags, cv_pair, use_tbb);
+      hasher_push_cv(self, cv_pair, self->chunk.chunk_counter);
+      hasher_push_cv(self, &cv_pair[BLAKE3_OUT_LEN],
+                     self->chunk.chunk_counter + (subtree_chunks / 2));
+    }
+    self->chunk.chunk_counter += subtree_chunks;
+    input_bytes += subtree_len;
+    input_len -= subtree_len;
+  }
+
+  // If there's any remaining input less than a full chunk, add it to the chunk
+  // state. In that case, also do a final merge loop to make sure the subtree
+  // stack doesn't contain any unmerged pairs. The remaining input means we
+  // know these merges are non-root. This merge loop isn't strictly necessary
+  // here, because hasher_push_chunk_cv already does its own merge loop, but it
+  // simplifies blake3_hasher_finalize below.
+  if (input_len > 0) {
+    chunk_state_update(&self->chunk, input_bytes, input_len);
+    hasher_merge_cv_stack(self, self->chunk.chunk_counter);
+  }
+}
+
+void blake3_hasher_update(blake3_hasher *self, const void *input,
+                          size_t input_len) {
+  bool use_tbb = false;
+  blake3_hasher_update_base(self, input, input_len, use_tbb);
+}
+
+#if defined(BLAKE3_USE_TBB)
+void blake3_hasher_update_tbb(blake3_hasher *self, const void *input,
+                              size_t input_len) {
+  bool use_tbb = true;
+  blake3_hasher_update_base(self, input, input_len, use_tbb);
+}
+#endif // BLAKE3_USE_TBB
+
+void blake3_hasher_finalize(const blake3_hasher *self, uint8_t *out,
+                            size_t out_len) {
+  blake3_hasher_finalize_seek(self, 0, out, out_len);
+}
+
+void blake3_hasher_finalize_seek(const blake3_hasher *self, uint64_t seek,
+                                 uint8_t *out, size_t out_len) {
+  // Explicitly checking for zero avoids causing UB by passing a null pointer
+  // to memcpy. This comes up in practice with things like:
+  //   std::vector<uint8_t> v;
+  //   blake3_hasher_finalize(&hasher, v.data(), v.size());
+  if (out_len == 0) {
+    return;
+  }
+
+  // If the subtree stack is empty, then the current chunk is the root.
+  if (self->cv_stack_len == 0) {
+    output_t output = chunk_state_output(&self->chunk);
+    output_root_bytes(&output, seek, out, out_len);
+    return;
+  }
+  // If there are any bytes in the chunk state, finalize that chunk and do a
+  // roll-up merge between that chunk hash and every subtree in the stack. In
+  // this case, the extra merge loop at the end of blake3_hasher_update
+  // guarantees that none of the subtrees in the stack need to be merged with
+  // each other first. Otherwise, if there are no bytes in the chunk state,
+  // then the top of the stack is a chunk hash, and we start the merge from
+  // that.
+  output_t output;
+  size_t cvs_remaining;
+  if (chunk_state_len(&self->chunk) > 0) {
+    cvs_remaining = self->cv_stack_len;
+    output = chunk_state_output(&self->chunk);
+  } else {
+    // There are always at least 2 CVs in the stack in this case.
+    cvs_remaining = self->cv_stack_len - 2;
+    output = parent_output(&self->cv_stack[cvs_remaining * 32], self->key,
+                           self->chunk.flags);
+  }
+  while (cvs_remaining > 0) {
+    cvs_remaining -= 1;
+    uint8_t parent_block[BLAKE3_BLOCK_LEN];
+    memcpy(parent_block, &self->cv_stack[cvs_remaining * 32], 32);
+    output_chaining_value(&output, &parent_block[32]);
+    output = parent_output(parent_block, self->key, self->chunk.flags);
+  }
+  output_root_bytes(&output, seek, out, out_len);
+}
+
+void blake3_hasher_reset(blake3_hasher *self) {
+  chunk_state_reset(&self->chunk, self->key, 0);
+  self->cv_stack_len = 0;
+}

--- a/third_party/blake3/blake3.h
+++ b/third_party/blake3/blake3.h
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH
+// LLVM-exception
+
+#ifndef BLAKE3_H
+#define BLAKE3_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if !defined(BLAKE3_API)
+#if defined(_WIN32) || defined(__CYGWIN__)
+#if defined(BLAKE3_DLL)
+#if defined(BLAKE3_DLL_EXPORTS)
+#define BLAKE3_API __declspec(dllexport)
+#else
+#define BLAKE3_API __declspec(dllimport)
+#endif
+#define BLAKE3_PRIVATE
+#else
+#define BLAKE3_API
+#define BLAKE3_PRIVATE
+#endif
+#elif __GNUC__ >= 4
+#define BLAKE3_API __attribute__((visibility("default")))
+#define BLAKE3_PRIVATE __attribute__((visibility("hidden")))
+#else
+#define BLAKE3_API
+#define BLAKE3_PRIVATE
+#endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define BLAKE3_VERSION_STRING "1.8.2"
+#define BLAKE3_KEY_LEN 32
+#define BLAKE3_OUT_LEN 32
+#define BLAKE3_BLOCK_LEN 64
+#define BLAKE3_CHUNK_LEN 1024
+#define BLAKE3_MAX_DEPTH 54
+
+// This struct is a private implementation detail. It has to be here because
+// it's part of blake3_hasher below.
+typedef struct {
+  uint32_t cv[8];
+  uint64_t chunk_counter;
+  uint8_t buf[BLAKE3_BLOCK_LEN];
+  uint8_t buf_len;
+  uint8_t blocks_compressed;
+  uint8_t flags;
+} blake3_chunk_state;
+
+typedef struct {
+  uint32_t key[8];
+  blake3_chunk_state chunk;
+  uint8_t cv_stack_len;
+  // The stack size is MAX_DEPTH + 1 because we do lazy merging. For example,
+  // with 7 chunks, we have 3 entries in the stack. Adding an 8th chunk
+  // requires a 4th entry, rather than merging everything down to 1, because we
+  // don't know whether more input is coming. This is different from how the
+  // reference implementation does things.
+  uint8_t cv_stack[(BLAKE3_MAX_DEPTH + 1) * BLAKE3_OUT_LEN];
+} blake3_hasher;
+
+BLAKE3_API const char *blake3_version(void);
+BLAKE3_API void blake3_hasher_init(blake3_hasher *self);
+BLAKE3_API void blake3_hasher_init_keyed(blake3_hasher *self,
+                                         const uint8_t key[BLAKE3_KEY_LEN]);
+BLAKE3_API void blake3_hasher_init_derive_key(blake3_hasher *self,
+                                              const char *context);
+BLAKE3_API void blake3_hasher_init_derive_key_raw(blake3_hasher *self,
+                                                  const void *context,
+                                                  size_t context_len);
+BLAKE3_API void blake3_hasher_update(blake3_hasher *self, const void *input,
+                                     size_t input_len);
+#if defined(BLAKE3_USE_TBB)
+BLAKE3_API void blake3_hasher_update_tbb(blake3_hasher *self, const void *input,
+                                         size_t input_len);
+#endif // BLAKE3_USE_TBB
+BLAKE3_API void blake3_hasher_finalize(const blake3_hasher *self, uint8_t *out,
+                                       size_t out_len);
+BLAKE3_API void blake3_hasher_finalize_seek(const blake3_hasher *self,
+                                            uint64_t seek, uint8_t *out,
+                                            size_t out_len);
+BLAKE3_API void blake3_hasher_reset(blake3_hasher *self);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BLAKE3_H */

--- a/third_party/blake3/blake3_dispatch.c
+++ b/third_party/blake3/blake3_dispatch.c
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH
+// LLVM-exception
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "blake3_impl.h"
+
+#if defined(_MSC_VER)
+#include <Windows.h>
+#endif
+
+#if defined(IS_X86)
+#if defined(_MSC_VER)
+#include <intrin.h>
+#elif defined(__GNUC__)
+#include <immintrin.h>
+#else
+#undef IS_X86 /* Unimplemented! */
+#endif
+#endif
+
+#if !defined(BLAKE3_ATOMICS)
+#if defined(__has_include)
+#if __has_include(<stdatomic.h>) && !defined(_MSC_VER)
+#define BLAKE3_ATOMICS 1
+#else
+#define BLAKE3_ATOMICS 0
+#endif /* __has_include(<stdatomic.h>) && !defined(_MSC_VER) */
+#else
+#define BLAKE3_ATOMICS 0
+#endif /* defined(__has_include) */
+#endif /* BLAKE3_ATOMICS */
+
+#if BLAKE3_ATOMICS
+#define ATOMIC_INT _Atomic int
+#define ATOMIC_LOAD(x) x
+#define ATOMIC_STORE(x, y) x = y
+#elif defined(_MSC_VER)
+#define ATOMIC_INT LONG
+#define ATOMIC_LOAD(x) InterlockedOr(&x, 0)
+#define ATOMIC_STORE(x, y) InterlockedExchange(&x, y)
+#else
+#define ATOMIC_INT int
+#define ATOMIC_LOAD(x) x
+#define ATOMIC_STORE(x, y) x = y
+#endif
+
+#define MAYBE_UNUSED(x) (void)((x))
+
+#if defined(IS_X86)
+static uint64_t xgetbv(void) {
+#if defined(_MSC_VER)
+  return _xgetbv(0);
+#else
+  uint32_t eax = 0, edx = 0;
+  __asm__ __volatile__("xgetbv\n" : "=a"(eax), "=d"(edx) : "c"(0));
+  return ((uint64_t)edx << 32) | eax;
+#endif
+}
+
+static void cpuid(uint32_t out[4], uint32_t id) {
+#if defined(_MSC_VER)
+  __cpuid((int *)out, id);
+#elif defined(__i386__) || defined(_M_IX86)
+  __asm__ __volatile__("movl %%ebx, %1\n"
+                       "cpuid\n"
+                       "xchgl %1, %%ebx\n"
+                       : "=a"(out[0]), "=r"(out[1]), "=c"(out[2]), "=d"(out[3])
+                       : "a"(id));
+#else
+  __asm__ __volatile__("cpuid\n"
+                       : "=a"(out[0]), "=b"(out[1]), "=c"(out[2]), "=d"(out[3])
+                       : "a"(id));
+#endif
+}
+
+static void cpuidex(uint32_t out[4], uint32_t id, uint32_t sid) {
+#if defined(_MSC_VER)
+  __cpuidex((int *)out, id, sid);
+#elif defined(__i386__) || defined(_M_IX86)
+  __asm__ __volatile__("movl %%ebx, %1\n"
+                       "cpuid\n"
+                       "xchgl %1, %%ebx\n"
+                       : "=a"(out[0]), "=r"(out[1]), "=c"(out[2]), "=d"(out[3])
+                       : "a"(id), "c"(sid));
+#else
+  __asm__ __volatile__("cpuid\n"
+                       : "=a"(out[0]), "=b"(out[1]), "=c"(out[2]), "=d"(out[3])
+                       : "a"(id), "c"(sid));
+#endif
+}
+
+#endif
+
+enum cpu_feature {
+  SSE2 = 1 << 0,
+  SSSE3 = 1 << 1,
+  SSE41 = 1 << 2,
+  AVX = 1 << 3,
+  AVX2 = 1 << 4,
+  AVX512F = 1 << 5,
+  AVX512VL = 1 << 6,
+  /* ... */
+  UNDEFINED = 1 << 30
+};
+
+#if !defined(BLAKE3_TESTING)
+static /* Allow the variable to be controlled manually for testing */
+#endif
+    ATOMIC_INT g_cpu_features = UNDEFINED;
+
+#if !defined(BLAKE3_TESTING)
+static
+#endif
+    enum cpu_feature
+    get_cpu_features(void) {
+
+  /* If TSAN detects a data race here, try compiling with -DBLAKE3_ATOMICS=1 */
+  enum cpu_feature features = ATOMIC_LOAD(g_cpu_features);
+  if (features != UNDEFINED) {
+    return features;
+  } else {
+#if defined(IS_X86)
+    uint32_t regs[4] = {0};
+    uint32_t *eax = &regs[0], *ebx = &regs[1], *ecx = &regs[2], *edx = &regs[3];
+    (void)edx;
+    features = 0;
+    cpuid(regs, 0);
+    const int max_id = *eax;
+    cpuid(regs, 1);
+#if defined(__amd64__) || defined(_M_X64)
+    features |= SSE2;
+#else
+    if (*edx & (1UL << 26))
+      features |= SSE2;
+#endif
+    if (*ecx & (1UL << 9))
+      features |= SSSE3;
+    if (*ecx & (1UL << 19))
+      features |= SSE41;
+
+    if (*ecx & (1UL << 27)) { // OSXSAVE
+      const uint64_t mask = xgetbv();
+      if ((mask & 6) == 6) { // SSE and AVX states
+        if (*ecx & (1UL << 28))
+          features |= AVX;
+        if (max_id >= 7) {
+          cpuidex(regs, 7, 0);
+          if (*ebx & (1UL << 5))
+            features |= AVX2;
+          if ((mask & 224) == 224) { // Opmask, ZMM_Hi256, Hi16_Zmm
+            if (*ebx & (1UL << 31))
+              features |= AVX512VL;
+            if (*ebx & (1UL << 16))
+              features |= AVX512F;
+          }
+        }
+      }
+    }
+    ATOMIC_STORE(g_cpu_features, features);
+    return features;
+#else
+    /* How to detect NEON? */
+    return 0;
+#endif
+  }
+}
+
+void blake3_compress_in_place(uint32_t cv[8],
+                              const uint8_t block[BLAKE3_BLOCK_LEN],
+                              uint8_t block_len, uint64_t counter,
+                              uint8_t flags) {
+#if defined(IS_X86)
+  const enum cpu_feature features = get_cpu_features();
+  MAYBE_UNUSED(features);
+#if !defined(BLAKE3_NO_AVX512)
+  if (features & AVX512VL) {
+    blake3_compress_in_place_avx512(cv, block, block_len, counter, flags);
+    return;
+  }
+#endif
+#if !defined(BLAKE3_NO_SSE41)
+  if (features & SSE41) {
+    blake3_compress_in_place_sse41(cv, block, block_len, counter, flags);
+    return;
+  }
+#endif
+#if !defined(BLAKE3_NO_SSE2)
+  if (features & SSE2) {
+    blake3_compress_in_place_sse2(cv, block, block_len, counter, flags);
+    return;
+  }
+#endif
+#endif
+  blake3_compress_in_place_portable(cv, block, block_len, counter, flags);
+}
+
+void blake3_compress_xof(const uint32_t cv[8],
+                         const uint8_t block[BLAKE3_BLOCK_LEN],
+                         uint8_t block_len, uint64_t counter, uint8_t flags,
+                         uint8_t out[64]) {
+#if defined(IS_X86)
+  const enum cpu_feature features = get_cpu_features();
+  MAYBE_UNUSED(features);
+#if !defined(BLAKE3_NO_AVX512)
+  if (features & AVX512VL) {
+    blake3_compress_xof_avx512(cv, block, block_len, counter, flags, out);
+    return;
+  }
+#endif
+#if !defined(BLAKE3_NO_SSE41)
+  if (features & SSE41) {
+    blake3_compress_xof_sse41(cv, block, block_len, counter, flags, out);
+    return;
+  }
+#endif
+#if !defined(BLAKE3_NO_SSE2)
+  if (features & SSE2) {
+    blake3_compress_xof_sse2(cv, block, block_len, counter, flags, out);
+    return;
+  }
+#endif
+#endif
+  blake3_compress_xof_portable(cv, block, block_len, counter, flags, out);
+}
+
+void blake3_xof_many(const uint32_t cv[8],
+                     const uint8_t block[BLAKE3_BLOCK_LEN], uint8_t block_len,
+                     uint64_t counter, uint8_t flags, uint8_t out[64],
+                     size_t outblocks) {
+  if (outblocks == 0) {
+    // The current assembly implementation always outputs at least 1 block.
+    return;
+  }
+#if defined(IS_X86)
+  const enum cpu_feature features = get_cpu_features();
+  MAYBE_UNUSED(features);
+#if !defined(_WIN32) && !defined(BLAKE3_NO_AVX512)
+  if (features & AVX512VL) {
+    blake3_xof_many_avx512(cv, block, block_len, counter, flags, out,
+                           outblocks);
+    return;
+  }
+#endif
+#endif
+  for (size_t i = 0; i < outblocks; ++i) {
+    blake3_compress_xof(cv, block, block_len, counter + i, flags, out + 64 * i);
+  }
+}
+
+void blake3_hash_many(const uint8_t *const *inputs, size_t num_inputs,
+                      size_t blocks, const uint32_t key[8], uint64_t counter,
+                      bool increment_counter, uint8_t flags,
+                      uint8_t flags_start, uint8_t flags_end, uint8_t *out) {
+#if defined(IS_X86)
+  const enum cpu_feature features = get_cpu_features();
+  MAYBE_UNUSED(features);
+#if !defined(BLAKE3_NO_AVX512)
+  if ((features & (AVX512F | AVX512VL)) == (AVX512F | AVX512VL)) {
+    blake3_hash_many_avx512(inputs, num_inputs, blocks, key, counter,
+                            increment_counter, flags, flags_start, flags_end,
+                            out);
+    return;
+  }
+#endif
+#if !defined(BLAKE3_NO_AVX2)
+  if (features & AVX2) {
+    blake3_hash_many_avx2(inputs, num_inputs, blocks, key, counter,
+                          increment_counter, flags, flags_start, flags_end,
+                          out);
+    return;
+  }
+#endif
+#if !defined(BLAKE3_NO_SSE41)
+  if (features & SSE41) {
+    blake3_hash_many_sse41(inputs, num_inputs, blocks, key, counter,
+                           increment_counter, flags, flags_start, flags_end,
+                           out);
+    return;
+  }
+#endif
+#if !defined(BLAKE3_NO_SSE2)
+  if (features & SSE2) {
+    blake3_hash_many_sse2(inputs, num_inputs, blocks, key, counter,
+                          increment_counter, flags, flags_start, flags_end,
+                          out);
+    return;
+  }
+#endif
+#endif
+
+#if BLAKE3_USE_NEON == 1
+  blake3_hash_many_neon(inputs, num_inputs, blocks, key, counter,
+                        increment_counter, flags, flags_start, flags_end, out);
+  return;
+#endif
+
+  blake3_hash_many_portable(inputs, num_inputs, blocks, key, counter,
+                            increment_counter, flags, flags_start, flags_end,
+                            out);
+}
+
+// The dynamically detected SIMD degree of the current platform.
+size_t blake3_simd_degree(void) {
+#if defined(IS_X86)
+  const enum cpu_feature features = get_cpu_features();
+  MAYBE_UNUSED(features);
+#if !defined(BLAKE3_NO_AVX512)
+  if ((features & (AVX512F | AVX512VL)) == (AVX512F | AVX512VL)) {
+    return 16;
+  }
+#endif
+#if !defined(BLAKE3_NO_AVX2)
+  if (features & AVX2) {
+    return 8;
+  }
+#endif
+#if !defined(BLAKE3_NO_SSE41)
+  if (features & SSE41) {
+    return 4;
+  }
+#endif
+#if !defined(BLAKE3_NO_SSE2)
+  if (features & SSE2) {
+    return 4;
+  }
+#endif
+#endif
+#if BLAKE3_USE_NEON == 1
+  return 4;
+#endif
+  return 1;
+}

--- a/third_party/blake3/blake3_impl.h
+++ b/third_party/blake3/blake3_impl.h
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH
+// LLVM-exception
+
+#ifndef BLAKE3_IMPL_H
+#define BLAKE3_IMPL_H
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "blake3.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// internal flags
+enum blake3_flags {
+  CHUNK_START = 1 << 0,
+  CHUNK_END = 1 << 1,
+  PARENT = 1 << 2,
+  ROOT = 1 << 3,
+  KEYED_HASH = 1 << 4,
+  DERIVE_KEY_CONTEXT = 1 << 5,
+  DERIVE_KEY_MATERIAL = 1 << 6,
+};
+
+// This C implementation tries to support recent versions of GCC, Clang, and
+// MSVC.
+#if defined(_MSC_VER)
+#define INLINE static __forceinline
+#else
+#define INLINE static inline __attribute__((always_inline))
+#endif
+
+#ifdef __cplusplus
+#define NOEXCEPT noexcept
+#else
+#define NOEXCEPT
+#endif
+
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_M_ARM64EC)
+#define IS_X86
+#define IS_X86_64
+#endif
+
+#if defined(__i386__) || defined(_M_IX86)
+#define IS_X86
+#define IS_X86_32
+#endif
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+#define IS_AARCH64
+#endif
+
+#if defined(IS_X86)
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+#endif
+
+#if !defined(BLAKE3_USE_NEON)
+// If BLAKE3_USE_NEON not manually set, autodetect based on AArch64ness
+#if defined(IS_AARCH64)
+#if defined(__ARM_BIG_ENDIAN)
+#define BLAKE3_USE_NEON 0
+#else
+#define BLAKE3_USE_NEON 1
+#endif
+#else
+#define BLAKE3_USE_NEON 0
+#endif
+#endif
+
+#if defined(IS_X86)
+#define MAX_SIMD_DEGREE 16
+#elif BLAKE3_USE_NEON == 1
+#define MAX_SIMD_DEGREE 4
+#else
+#define MAX_SIMD_DEGREE 1
+#endif
+
+// There are some places where we want a static size that's equal to the
+// MAX_SIMD_DEGREE, but also at least 2.
+#define MAX_SIMD_DEGREE_OR_2 (MAX_SIMD_DEGREE > 2 ? MAX_SIMD_DEGREE : 2)
+
+static const uint32_t IV[8] = {0x6A09E667UL, 0xBB67AE85UL, 0x3C6EF372UL,
+                               0xA54FF53AUL, 0x510E527FUL, 0x9B05688CUL,
+                               0x1F83D9ABUL, 0x5BE0CD19UL};
+
+static const uint8_t MSG_SCHEDULE[7][16] = {
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+    {2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8},
+    {3, 4, 10, 12, 13, 2, 7, 14, 6, 5, 9, 0, 11, 15, 8, 1},
+    {10, 7, 12, 9, 14, 3, 13, 15, 4, 0, 11, 2, 5, 8, 1, 6},
+    {12, 13, 9, 11, 15, 10, 14, 8, 7, 2, 5, 3, 0, 1, 6, 4},
+    {9, 14, 11, 5, 8, 12, 15, 1, 13, 3, 0, 10, 2, 6, 4, 7},
+    {11, 15, 5, 0, 1, 9, 8, 6, 14, 10, 2, 12, 3, 4, 7, 13},
+};
+
+/* Find index of the highest set bit */
+/* x is assumed to be nonzero.       */
+static unsigned int highest_one(uint64_t x) {
+#if defined(__GNUC__) || defined(__clang__)
+  return 63 ^ (unsigned int)__builtin_clzll(x);
+#elif defined(_MSC_VER) && defined(IS_X86_64)
+  unsigned long index;
+  _BitScanReverse64(&index, x);
+  return index;
+#elif defined(_MSC_VER) && defined(IS_X86_32)
+  if (x >> 32) {
+    unsigned long index;
+    _BitScanReverse(&index, (unsigned long)(x >> 32));
+    return 32 + index;
+  } else {
+    unsigned long index;
+    _BitScanReverse(&index, (unsigned long)x);
+    return index;
+  }
+#else
+  unsigned int c = 0;
+  if (x & 0xffffffff00000000ULL) {
+    x >>= 32;
+    c += 32;
+  }
+  if (x & 0x00000000ffff0000ULL) {
+    x >>= 16;
+    c += 16;
+  }
+  if (x & 0x000000000000ff00ULL) {
+    x >>= 8;
+    c += 8;
+  }
+  if (x & 0x00000000000000f0ULL) {
+    x >>= 4;
+    c += 4;
+  }
+  if (x & 0x000000000000000cULL) {
+    x >>= 2;
+    c += 2;
+  }
+  if (x & 0x0000000000000002ULL) {
+    c += 1;
+  }
+  return c;
+#endif
+}
+
+// Count the number of 1 bits.
+INLINE unsigned int popcnt(uint64_t x) {
+#if defined(__GNUC__) || defined(__clang__)
+  return (unsigned int)__builtin_popcountll(x);
+#else
+  unsigned int count = 0;
+  while (x != 0) {
+    count += 1;
+    x &= x - 1;
+  }
+  return count;
+#endif
+}
+
+// Largest power of two less than or equal to x. As a special case, returns 1
+// when x is 0.
+INLINE uint64_t round_down_to_power_of_2(uint64_t x) {
+  return 1ULL << highest_one(x | 1);
+}
+
+INLINE uint32_t counter_low(uint64_t counter) { return (uint32_t)counter; }
+
+INLINE uint32_t counter_high(uint64_t counter) {
+  return (uint32_t)(counter >> 32);
+}
+
+INLINE uint32_t load32(const void *src) {
+  const uint8_t *p = (const uint8_t *)src;
+  return ((uint32_t)(p[0]) << 0) | ((uint32_t)(p[1]) << 8) |
+         ((uint32_t)(p[2]) << 16) | ((uint32_t)(p[3]) << 24);
+}
+
+INLINE void load_key_words(const uint8_t key[BLAKE3_KEY_LEN],
+                           uint32_t key_words[8]) {
+  key_words[0] = load32(&key[0 * 4]);
+  key_words[1] = load32(&key[1 * 4]);
+  key_words[2] = load32(&key[2 * 4]);
+  key_words[3] = load32(&key[3 * 4]);
+  key_words[4] = load32(&key[4 * 4]);
+  key_words[5] = load32(&key[5 * 4]);
+  key_words[6] = load32(&key[6 * 4]);
+  key_words[7] = load32(&key[7 * 4]);
+}
+
+INLINE void load_block_words(const uint8_t block[BLAKE3_BLOCK_LEN],
+                             uint32_t block_words[16]) {
+  for (size_t i = 0; i < 16; i++) {
+    block_words[i] = load32(&block[i * 4]);
+  }
+}
+
+INLINE void store32(void *dst, uint32_t w) {
+  uint8_t *p = (uint8_t *)dst;
+  p[0] = (uint8_t)(w >> 0);
+  p[1] = (uint8_t)(w >> 8);
+  p[2] = (uint8_t)(w >> 16);
+  p[3] = (uint8_t)(w >> 24);
+}
+
+INLINE void store_cv_words(uint8_t bytes_out[32], uint32_t cv_words[8]) {
+  store32(&bytes_out[0 * 4], cv_words[0]);
+  store32(&bytes_out[1 * 4], cv_words[1]);
+  store32(&bytes_out[2 * 4], cv_words[2]);
+  store32(&bytes_out[3 * 4], cv_words[3]);
+  store32(&bytes_out[4 * 4], cv_words[4]);
+  store32(&bytes_out[5 * 4], cv_words[5]);
+  store32(&bytes_out[6 * 4], cv_words[6]);
+  store32(&bytes_out[7 * 4], cv_words[7]);
+}
+
+void blake3_compress_in_place(uint32_t cv[8],
+                              const uint8_t block[BLAKE3_BLOCK_LEN],
+                              uint8_t block_len, uint64_t counter,
+                              uint8_t flags);
+
+void blake3_compress_xof(const uint32_t cv[8],
+                         const uint8_t block[BLAKE3_BLOCK_LEN],
+                         uint8_t block_len, uint64_t counter, uint8_t flags,
+                         uint8_t out[64]);
+
+void blake3_xof_many(const uint32_t cv[8],
+                     const uint8_t block[BLAKE3_BLOCK_LEN], uint8_t block_len,
+                     uint64_t counter, uint8_t flags, uint8_t out[64],
+                     size_t outblocks);
+
+void blake3_hash_many(const uint8_t *const *inputs, size_t num_inputs,
+                      size_t blocks, const uint32_t key[8], uint64_t counter,
+                      bool increment_counter, uint8_t flags,
+                      uint8_t flags_start, uint8_t flags_end, uint8_t *out);
+
+size_t blake3_simd_degree(void);
+
+BLAKE3_PRIVATE size_t blake3_compress_subtree_wide(
+    const uint8_t *input, size_t input_len, const uint32_t key[8],
+    uint64_t chunk_counter, uint8_t flags, uint8_t *out, bool use_tbb);
+
+#if defined(BLAKE3_USE_TBB)
+BLAKE3_PRIVATE void blake3_compress_subtree_wide_join_tbb(
+    // shared params
+    const uint32_t key[8], uint8_t flags, bool use_tbb,
+    // left-hand side params
+    const uint8_t *l_input, size_t l_input_len, uint64_t l_chunk_counter,
+    uint8_t *l_cvs, size_t *l_n,
+    // right-hand side params
+    const uint8_t *r_input, size_t r_input_len, uint64_t r_chunk_counter,
+    uint8_t *r_cvs, size_t *r_n) NOEXCEPT;
+#endif
+
+// Declarations for implementation-specific functions.
+void blake3_compress_in_place_portable(uint32_t cv[8],
+                                       const uint8_t block[BLAKE3_BLOCK_LEN],
+                                       uint8_t block_len, uint64_t counter,
+                                       uint8_t flags);
+
+void blake3_compress_xof_portable(const uint32_t cv[8],
+                                  const uint8_t block[BLAKE3_BLOCK_LEN],
+                                  uint8_t block_len, uint64_t counter,
+                                  uint8_t flags, uint8_t out[64]);
+
+void blake3_hash_many_portable(const uint8_t *const *inputs, size_t num_inputs,
+                               size_t blocks, const uint32_t key[8],
+                               uint64_t counter, bool increment_counter,
+                               uint8_t flags, uint8_t flags_start,
+                               uint8_t flags_end, uint8_t *out);
+
+#if defined(IS_X86)
+#if !defined(BLAKE3_NO_SSE2)
+void blake3_compress_in_place_sse2(uint32_t cv[8],
+                                   const uint8_t block[BLAKE3_BLOCK_LEN],
+                                   uint8_t block_len, uint64_t counter,
+                                   uint8_t flags);
+void blake3_compress_xof_sse2(const uint32_t cv[8],
+                              const uint8_t block[BLAKE3_BLOCK_LEN],
+                              uint8_t block_len, uint64_t counter,
+                              uint8_t flags, uint8_t out[64]);
+void blake3_hash_many_sse2(const uint8_t *const *inputs, size_t num_inputs,
+                           size_t blocks, const uint32_t key[8],
+                           uint64_t counter, bool increment_counter,
+                           uint8_t flags, uint8_t flags_start,
+                           uint8_t flags_end, uint8_t *out);
+#endif
+#if !defined(BLAKE3_NO_SSE41)
+void blake3_compress_in_place_sse41(uint32_t cv[8],
+                                    const uint8_t block[BLAKE3_BLOCK_LEN],
+                                    uint8_t block_len, uint64_t counter,
+                                    uint8_t flags);
+void blake3_compress_xof_sse41(const uint32_t cv[8],
+                               const uint8_t block[BLAKE3_BLOCK_LEN],
+                               uint8_t block_len, uint64_t counter,
+                               uint8_t flags, uint8_t out[64]);
+void blake3_hash_many_sse41(const uint8_t *const *inputs, size_t num_inputs,
+                            size_t blocks, const uint32_t key[8],
+                            uint64_t counter, bool increment_counter,
+                            uint8_t flags, uint8_t flags_start,
+                            uint8_t flags_end, uint8_t *out);
+#endif
+#if !defined(BLAKE3_NO_AVX2)
+void blake3_hash_many_avx2(const uint8_t *const *inputs, size_t num_inputs,
+                           size_t blocks, const uint32_t key[8],
+                           uint64_t counter, bool increment_counter,
+                           uint8_t flags, uint8_t flags_start,
+                           uint8_t flags_end, uint8_t *out);
+#endif
+#if !defined(BLAKE3_NO_AVX512)
+void blake3_compress_in_place_avx512(uint32_t cv[8],
+                                     const uint8_t block[BLAKE3_BLOCK_LEN],
+                                     uint8_t block_len, uint64_t counter,
+                                     uint8_t flags);
+
+void blake3_compress_xof_avx512(const uint32_t cv[8],
+                                const uint8_t block[BLAKE3_BLOCK_LEN],
+                                uint8_t block_len, uint64_t counter,
+                                uint8_t flags, uint8_t out[64]);
+
+void blake3_hash_many_avx512(const uint8_t *const *inputs, size_t num_inputs,
+                             size_t blocks, const uint32_t key[8],
+                             uint64_t counter, bool increment_counter,
+                             uint8_t flags, uint8_t flags_start,
+                             uint8_t flags_end, uint8_t *out);
+
+#if !defined(_WIN32)
+void blake3_xof_many_avx512(const uint32_t cv[8],
+                            const uint8_t block[BLAKE3_BLOCK_LEN],
+                            uint8_t block_len, uint64_t counter, uint8_t flags,
+                            uint8_t *out, size_t outblocks);
+#endif
+#endif
+#endif
+
+#if BLAKE3_USE_NEON == 1
+void blake3_hash_many_neon(const uint8_t *const *inputs, size_t num_inputs,
+                           size_t blocks, const uint32_t key[8],
+                           uint64_t counter, bool increment_counter,
+                           uint8_t flags, uint8_t flags_start,
+                           uint8_t flags_end, uint8_t *out);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BLAKE3_IMPL_H */

--- a/third_party/blake3/blake3_portable.c
+++ b/third_party/blake3/blake3_portable.c
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH
+// LLVM-exception
+
+#include "blake3_impl.h"
+#include <string.h>
+
+INLINE uint32_t rotr32(uint32_t w, uint32_t c) {
+  return (w >> c) | (w << (32 - c));
+}
+
+INLINE void g(uint32_t *state, size_t a, size_t b, size_t c, size_t d,
+              uint32_t x, uint32_t y) {
+  state[a] = state[a] + state[b] + x;
+  state[d] = rotr32(state[d] ^ state[a], 16);
+  state[c] = state[c] + state[d];
+  state[b] = rotr32(state[b] ^ state[c], 12);
+  state[a] = state[a] + state[b] + y;
+  state[d] = rotr32(state[d] ^ state[a], 8);
+  state[c] = state[c] + state[d];
+  state[b] = rotr32(state[b] ^ state[c], 7);
+}
+
+INLINE void round_fn(uint32_t state[16], const uint32_t *msg, size_t round) {
+  // Select the message schedule based on the round.
+  const uint8_t *schedule = MSG_SCHEDULE[round];
+
+  // Mix the columns.
+  g(state, 0, 4, 8, 12, msg[schedule[0]], msg[schedule[1]]);
+  g(state, 1, 5, 9, 13, msg[schedule[2]], msg[schedule[3]]);
+  g(state, 2, 6, 10, 14, msg[schedule[4]], msg[schedule[5]]);
+  g(state, 3, 7, 11, 15, msg[schedule[6]], msg[schedule[7]]);
+
+  // Mix the rows.
+  g(state, 0, 5, 10, 15, msg[schedule[8]], msg[schedule[9]]);
+  g(state, 1, 6, 11, 12, msg[schedule[10]], msg[schedule[11]]);
+  g(state, 2, 7, 8, 13, msg[schedule[12]], msg[schedule[13]]);
+  g(state, 3, 4, 9, 14, msg[schedule[14]], msg[schedule[15]]);
+}
+
+INLINE void compress_pre(uint32_t state[16], const uint32_t cv[8],
+                         const uint8_t block[BLAKE3_BLOCK_LEN],
+                         uint8_t block_len, uint64_t counter, uint8_t flags) {
+  uint32_t block_words[16];
+  block_words[0] = load32(block + 4 * 0);
+  block_words[1] = load32(block + 4 * 1);
+  block_words[2] = load32(block + 4 * 2);
+  block_words[3] = load32(block + 4 * 3);
+  block_words[4] = load32(block + 4 * 4);
+  block_words[5] = load32(block + 4 * 5);
+  block_words[6] = load32(block + 4 * 6);
+  block_words[7] = load32(block + 4 * 7);
+  block_words[8] = load32(block + 4 * 8);
+  block_words[9] = load32(block + 4 * 9);
+  block_words[10] = load32(block + 4 * 10);
+  block_words[11] = load32(block + 4 * 11);
+  block_words[12] = load32(block + 4 * 12);
+  block_words[13] = load32(block + 4 * 13);
+  block_words[14] = load32(block + 4 * 14);
+  block_words[15] = load32(block + 4 * 15);
+
+  state[0] = cv[0];
+  state[1] = cv[1];
+  state[2] = cv[2];
+  state[3] = cv[3];
+  state[4] = cv[4];
+  state[5] = cv[5];
+  state[6] = cv[6];
+  state[7] = cv[7];
+  state[8] = IV[0];
+  state[9] = IV[1];
+  state[10] = IV[2];
+  state[11] = IV[3];
+  state[12] = counter_low(counter);
+  state[13] = counter_high(counter);
+  state[14] = (uint32_t)block_len;
+  state[15] = (uint32_t)flags;
+
+  round_fn(state, &block_words[0], 0);
+  round_fn(state, &block_words[0], 1);
+  round_fn(state, &block_words[0], 2);
+  round_fn(state, &block_words[0], 3);
+  round_fn(state, &block_words[0], 4);
+  round_fn(state, &block_words[0], 5);
+  round_fn(state, &block_words[0], 6);
+}
+
+void blake3_compress_in_place_portable(uint32_t cv[8],
+                                       const uint8_t block[BLAKE3_BLOCK_LEN],
+                                       uint8_t block_len, uint64_t counter,
+                                       uint8_t flags) {
+  uint32_t state[16];
+  compress_pre(state, cv, block, block_len, counter, flags);
+  cv[0] = state[0] ^ state[8];
+  cv[1] = state[1] ^ state[9];
+  cv[2] = state[2] ^ state[10];
+  cv[3] = state[3] ^ state[11];
+  cv[4] = state[4] ^ state[12];
+  cv[5] = state[5] ^ state[13];
+  cv[6] = state[6] ^ state[14];
+  cv[7] = state[7] ^ state[15];
+}
+
+void blake3_compress_xof_portable(const uint32_t cv[8],
+                                  const uint8_t block[BLAKE3_BLOCK_LEN],
+                                  uint8_t block_len, uint64_t counter,
+                                  uint8_t flags, uint8_t out[64]) {
+  uint32_t state[16];
+  compress_pre(state, cv, block, block_len, counter, flags);
+
+  store32(&out[0 * 4], state[0] ^ state[8]);
+  store32(&out[1 * 4], state[1] ^ state[9]);
+  store32(&out[2 * 4], state[2] ^ state[10]);
+  store32(&out[3 * 4], state[3] ^ state[11]);
+  store32(&out[4 * 4], state[4] ^ state[12]);
+  store32(&out[5 * 4], state[5] ^ state[13]);
+  store32(&out[6 * 4], state[6] ^ state[14]);
+  store32(&out[7 * 4], state[7] ^ state[15]);
+  store32(&out[8 * 4], state[8] ^ cv[0]);
+  store32(&out[9 * 4], state[9] ^ cv[1]);
+  store32(&out[10 * 4], state[10] ^ cv[2]);
+  store32(&out[11 * 4], state[11] ^ cv[3]);
+  store32(&out[12 * 4], state[12] ^ cv[4]);
+  store32(&out[13 * 4], state[13] ^ cv[5]);
+  store32(&out[14 * 4], state[14] ^ cv[6]);
+  store32(&out[15 * 4], state[15] ^ cv[7]);
+}
+
+INLINE void hash_one_portable(const uint8_t *input, size_t blocks,
+                              const uint32_t key[8], uint64_t counter,
+                              uint8_t flags, uint8_t flags_start,
+                              uint8_t flags_end, uint8_t out[BLAKE3_OUT_LEN]) {
+  uint32_t cv[8];
+  memcpy(cv, key, BLAKE3_KEY_LEN);
+  uint8_t block_flags = flags | flags_start;
+  while (blocks > 0) {
+    if (blocks == 1) {
+      block_flags |= flags_end;
+    }
+    blake3_compress_in_place_portable(cv, input, BLAKE3_BLOCK_LEN, counter,
+                                      block_flags);
+    input = &input[BLAKE3_BLOCK_LEN];
+    blocks -= 1;
+    block_flags = flags;
+  }
+  store_cv_words(out, cv);
+}
+
+void blake3_hash_many_portable(const uint8_t *const *inputs, size_t num_inputs,
+                               size_t blocks, const uint32_t key[8],
+                               uint64_t counter, bool increment_counter,
+                               uint8_t flags, uint8_t flags_start,
+                               uint8_t flags_end, uint8_t *out) {
+  while (num_inputs > 0) {
+    hash_one_portable(inputs[0], blocks, key, counter, flags, flags_start,
+                      flags_end, out);
+    if (increment_counter) {
+      counter += 1;
+    }
+    inputs += 1;
+    num_inputs -= 1;
+    out = &out[BLAKE3_OUT_LEN];
+  }
+}


### PR DESCRIPTION
## Summary
- vendor blake3 single-header implementation
- update utilities to hash with BLAKE3
- adjust CID generation for new digest
- rewrite FIPS self test and related docs
- update tests expecting specific digests
- allow SHA256 or BLAKE3 via HashAlgorithm enum

## Testing
- `cmake ..`
- `make -j`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6855cec779ec8328a912197668099d9b