### PR TITLE
Fix release workflow env reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GIT_SHA: ${{ github.sha }}
-      IMAGE: us-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/simplidfs/simplidfs-metaserver:${{ env.GIT_SHA }}
+      IMAGE: us-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/simplidfs/simplidfs-metaserver:${{ github.sha }}
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- fix unrecognized `env` expression in `release.yml`

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685dbe99111c8328b6b1c7c9d4780e98